### PR TITLE
feat: UI/UX overhaul — Warm Ledger design, Phase 4 edit, filter bar, mobile scaffold

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', '.agents', 'mobile'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/index.html
+++ b/index.html
@@ -2,9 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>VistaFi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,12 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { StatusBar } from 'expo-status-bar';
+import { AppNavigator } from './src/navigation/AppNavigator';
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <StatusBar style="auto" />
+      <AppNavigator />
+    </NavigationContainer>
+  );
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "VistaFi",
+    "slug": "vistafi",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "platforms": ["ios", "android"],
+    "sdkVersion": "52.0.0"
+  }
+}

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,0 +1,7 @@
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
+
+const config = getDefaultConfig(__dirname);
+config.watchFolders = [path.resolve(__dirname, '../shared')];
+
+module.exports = config;

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "vistafi-mobile",
+  "version": "1.0.0",
+  "main": "App.tsx",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "~52.0.0",
+    "expo-status-bar": "~2.0.0",
+    "react": "18.3.2",
+    "react-native": "0.76.3",
+    "@react-navigation/native": "^6.1.0",
+    "@react-navigation/bottom-tabs": "^6.5.0",
+    "react-native-safe-area-context": "4.12.0",
+    "react-native-screens": "~4.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "~18.3.12",
+    "typescript": "^5.3.0"
+  }
+}

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -1,0 +1,14 @@
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { HomeScreen } from '../screens/HomeScreen';
+import { AddTransactionScreen } from '../screens/AddTransactionScreen';
+
+const Tab = createBottomTabNavigator();
+
+export function AppNavigator() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Add" component={AddTransactionScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/mobile/src/screens/AddTransactionScreen.tsx
+++ b/mobile/src/screens/AddTransactionScreen.tsx
@@ -1,0 +1,19 @@
+import { View, Text, StyleSheet } from 'react-native';
+import type { BudgetCategory } from '@shared/types/budget';
+
+const categories: BudgetCategory[] = ['income', 'expense', 'savings'];
+
+export function AddTransactionScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Add Transaction</Text>
+      <Text style={styles.subtitle}>Categories: {categories.join(', ')}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#F5F2EC' },
+  title: { fontSize: 20, fontWeight: '600', color: '#18170F' },
+  subtitle: { marginTop: 8, fontSize: 14, color: '#857F72' },
+});

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import type { BudgetItem } from '@shared/types/budget';
+
+export function HomeScreen() {
+  const [items] = useState<BudgetItem[]>([]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>VistaFi</Text>
+      <Text style={styles.subtitle}>
+        {items.length === 0 ? 'No transactions yet' : `${items.length} transactions`}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#F5F2EC' },
+  title: { fontSize: 24, fontWeight: '700', color: '#18170F' },
+  subtitle: { marginTop: 8, fontSize: 14, color: '#857F72' },
+});

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["../shared/*"]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@types/node": "^25.3.3",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1602,6 +1603,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.2",
@@ -3592,6 +3603,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@types/node": "^25.3.3",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",

--- a/shared/data/mockData.ts
+++ b/shared/data/mockData.ts
@@ -50,4 +50,4 @@ export const mockBudgetItems: BudgetItem[] = [
         category: 'savings',
         date: '2023-11-02'
     }
-]; 
+];

--- a/shared/types/budget.ts
+++ b/shared/types/budget.ts
@@ -13,4 +13,4 @@ export interface BudgetSummary {
     totalExpenses: number;
     totalSavings: number;
     balance: number;
-} 
+}

--- a/shared/utils/budgetUtils.ts
+++ b/shared/utils/budgetUtils.ts
@@ -1,6 +1,5 @@
 import { BudgetItem, BudgetSummary } from '../types/budget';
 
-// Function to calculate the budget summary based on items
 export const calculateBudgetSummary = (items: BudgetItem[]): BudgetSummary => {
     const totalIncome = items
         .filter(item => item.category === 'income')
@@ -16,15 +15,9 @@ export const calculateBudgetSummary = (items: BudgetItem[]): BudgetSummary => {
 
     const balance = totalIncome - totalExpenses - totalSavings;
 
-    return {
-        totalIncome,
-        totalExpenses,
-        totalSavings,
-        balance
-    };
+    return { totalIncome, totalExpenses, totalSavings, balance };
 };
 
-// Generate unique ID for budget items
 export const generateId = (): string => {
     return Math.random().toString(36).substring(2, 9);
-}; 
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,17 @@
-import { useState, useEffect } from "react";
-import "./App.css";
+import { useState } from "react";
 import { BudgetForm } from "./components/BudgetForm";
 import { BudgetItemList } from "./components/BudgetItemList";
 import { BudgetSummary } from "./components/BudgetSummary";
-import { mockBudgetItems } from "./data/mockData";
-import { BudgetItem } from "./types/budget";
-import { calculateBudgetSummary } from "./utils/budgetUtils";
+import { FilterBar } from "./components/FilterBar";
+import { EditModal } from "./components/EditModal";
+import { mockBudgetItems } from "@shared/data/mockData";
+import { BudgetItem, BudgetCategory } from "@shared/types/budget";
+import { calculateBudgetSummary } from "@shared/utils/budgetUtils";
 
 function App() {
   const [budgetItems, setBudgetItems] = useState<BudgetItem[]>(mockBudgetItems);
   const [itemToEdit, setItemToEdit] = useState<BudgetItem | null>(null);
+  const [filterCategory, setFilterCategory] = useState<BudgetCategory | 'all'>('all');
 
   const handleAddItem = (newItem: BudgetItem) => {
     setBudgetItems([...budgetItems, newItem]);
@@ -20,44 +22,54 @@ function App() {
   };
 
   const handleEditItem = (item: BudgetItem) => {
-    // For now, just log the item. In a real app, you'd open a modal or form to edit the item
-    console.log("Edit item:", item);
     setItemToEdit(item);
+  };
 
-    // Here you could open a modal, update form values, etc.
-    // This is just a placeholder to demonstrate the edit functionality works
-    alert(
-      `Edit functionality not fully implemented. Would edit: ${item.description}`
-    );
+  const handleSaveEdit = (updated: BudgetItem) => {
+    setBudgetItems(budgetItems.map((item) => item.id === updated.id ? updated : item));
+    setItemToEdit(null);
+  };
+
+  const handleCancelEdit = () => {
+    setItemToEdit(null);
   };
 
   const summary = calculateBudgetSummary(budgetItems);
 
+  const filteredItems = filterCategory === 'all'
+    ? budgetItems
+    : budgetItems.filter(item => item.category === filterCategory);
+
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="max-w-5xl mx-auto p-4 sm:p-6 lg:p-8">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">VistaFi</h1>
-          <p className="text-gray-600">Simple Budget Planner</p>
-        </div>
+    <div className="min-h-screen bg-canvas">
+      <div className="max-w-5xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+        <header className="mb-8">
+          <h1 className="text-2xl font-bold text-ink">VistaFi</h1>
+          <p className="text-sm text-muted">Simple Budget Planner</p>
+        </header>
 
         <BudgetSummary summary={summary} />
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="md:col-span-1">
-            <BudgetForm onAddItem={handleAddItem} />
-          </div>
-
-          <div className="md:col-span-2">
-            <h2 className="text-xl font-semibold mb-4">Transaction History</h2>
+        <div className="grid grid-cols-1 md:grid-cols-[320px_1fr] gap-6 mt-8">
+          <BudgetForm onAddItem={handleAddItem} />
+          <div>
+            <FilterBar active={filterCategory} onChange={setFilterCategory} />
             <BudgetItemList
-              items={budgetItems}
+              items={filteredItems}
               onDeleteItem={handleDeleteItem}
               onEditItem={handleEditItem}
             />
           </div>
         </div>
       </div>
+
+      {itemToEdit && (
+        <EditModal
+          item={itemToEdit}
+          onSave={handleSaveEdit}
+          onCancel={handleCancelEdit}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/BudgetForm.tsx
+++ b/src/components/BudgetForm.tsx
@@ -1,131 +1,122 @@
 import { useState } from "react";
-import { BudgetCategory, BudgetItem } from "../types/budget";
-import { generateId } from "../utils/budgetUtils";
+import { BudgetCategory, BudgetItem } from "@shared/types/budget";
+import { generateId } from "@shared/utils/budgetUtils";
 
 interface BudgetFormProps {
   onAddItem: (item: BudgetItem) => void;
 }
 
 export const BudgetForm = ({ onAddItem }: BudgetFormProps) => {
-  const [description, setDescription] = useState("");
-  const [amount, setAmount] = useState("");
-  const [type, setType] = useState<"expense" | "income">("expense");
-  const [category, setCategory] = useState<BudgetCategory>("expense");
-  const [date] = useState(new Date().toISOString().split("T")[0]);
+  const [type, setType] = useState<'income' | 'expense'>('expense');
+  const [expenseCategory, setExpenseCategory] = useState<'expense' | 'savings'>('expense');
+  const [amount, setAmount] = useState('');
+  const [description, setDescription] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!description.trim() || !amount.trim() || parseFloat(amount) <= 0) return;
 
-    if (!description.trim() || !amount.trim()) {
-      return;
-    }
-
+    const category: BudgetCategory = type === 'income' ? 'income' : expenseCategory;
     const newItem: BudgetItem = {
       id: generateId(),
       description: description.trim(),
       amount: parseFloat(amount),
-      category: type === "income" ? "income" : category,
-      date,
+      category,
+      date: new Date().toISOString().split('T')[0],
     };
 
     onAddItem(newItem);
-
-    // Reset form
-    setDescription("");
-    setAmount("");
-    setType("expense");
-    setCategory("expense");
+    setDescription('');
+    setAmount('');
+    setType('expense');
+    setExpenseCategory('expense');
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="p-6 rounded-lg border border-gray-200 bg-white shadow-sm"
-    >
-      <h2 className="text-xl font-semibold mb-6">Quick Add</h2>
+    <form onSubmit={handleSubmit} className="bg-surface border border-border rounded-xl p-6">
+      <h2 className="text-base font-semibold text-ink mb-6">Quick Add</h2>
 
+      {/* Type segmented control */}
       <div className="mb-5">
-        <label className="block text-gray-700 font-medium mb-2">Type</label>
-        <div className="flex gap-6">
-          <label className="flex items-center">
-            <input
-              type="radio"
-              className="w-5 h-5 text-indigo-600 focus:ring-indigo-500"
-              checked={type === "expense"}
-              onChange={() => setType("expense")}
-            />
-            <span className="ml-2">Expense</span>
-          </label>
-          <label className="flex items-center">
-            <input
-              type="radio"
-              className="w-5 h-5 text-indigo-600 focus:ring-indigo-500"
-              checked={type === "income"}
-              onChange={() => setType("income")}
-            />
-            <span className="ml-2">Income</span>
-          </label>
+        <label className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+          Type
+        </label>
+        <div className="flex gap-2">
+          {(['income', 'expense'] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setType(t)}
+              className={`flex-1 h-9 rounded-lg text-sm font-medium cursor-pointer transition-colors duration-150 ${
+                type === t
+                  ? 'bg-ink text-surface'
+                  : 'border border-border text-muted hover:border-ink hover:text-ink'
+              }`}
+            >
+              {t === 'income' ? 'Income' : 'Expense'}
+            </button>
+          ))}
         </div>
       </div>
 
+      {/* Amount */}
       <div className="mb-5">
-        <label className="block text-gray-700 font-medium mb-2">Amount</label>
+        <label htmlFor="amount" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+          Amount
+        </label>
         <div className="relative">
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <span className="text-gray-500 text-lg">$</span>
-          </div>
+          <span className="absolute inset-y-0 left-3 flex items-center text-muted pointer-events-none">$</span>
           <input
+            id="amount"
             type="number"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             placeholder="0.00"
-            className="pl-8 pr-4 py-3 w-full border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
             step="0.01"
             min="0.01"
             required
+            className="w-full pl-8 pr-4 py-2.5 border border-border rounded-lg text-ink bg-transparent placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-ink num"
           />
         </div>
       </div>
 
-      <div className="mb-5">
-        <label className="block text-gray-700 font-medium mb-2">Category</label>
-        <select
-          value={category}
-          onChange={(e) => setCategory(e.target.value as BudgetCategory)}
-          className="w-full border border-gray-300 rounded-lg py-3 px-4 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 bg-white"
-          disabled={type === "income"}
-          required
-        >
-          <option value="" disabled>
-            Select category
-          </option>
-          {type === "expense" && (
-            <>
-              <option value="expense">General Expense</option>
-              <option value="savings">Savings</option>
-            </>
-          )}
-          {type === "income" && <option value="income">Income</option>}
-        </select>
-      </div>
+      {/* Category — only when expense */}
+      {type === 'expense' && (
+        <div className="mb-5">
+          <label htmlFor="category" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+            Category
+          </label>
+          <select
+            id="category"
+            value={expenseCategory}
+            onChange={(e) => setExpenseCategory(e.target.value as 'expense' | 'savings')}
+            className="w-full py-2.5 px-3 border border-border rounded-lg text-ink bg-surface focus:outline-none focus:ring-1 focus:ring-ink cursor-pointer"
+          >
+            <option value="expense">General Expense</option>
+            <option value="savings">Savings</option>
+          </select>
+        </div>
+      )}
 
+      {/* Description */}
       <div className="mb-6">
-        <label className="block text-gray-700 font-medium mb-2">
+        <label htmlFor="description" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
           Description
         </label>
         <input
+          id="description"
           type="text"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           placeholder="What's this for?"
-          className="w-full border border-gray-300 rounded-lg py-3 px-4 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
           required
+          className="w-full py-2.5 px-3 border border-border rounded-lg text-ink bg-transparent placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-ink"
         />
       </div>
 
       <button
         type="submit"
-        className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-3 px-4 rounded-lg transition-colors"
+        className="w-full min-h-[44px] bg-ink text-surface font-medium rounded-lg hover:opacity-90 cursor-pointer transition-opacity duration-150"
       >
         Add Transaction
       </button>

--- a/src/components/BudgetItemList.tsx
+++ b/src/components/BudgetItemList.tsx
@@ -1,97 +1,81 @@
-import { BudgetItem, BudgetCategory } from "../types/budget";
+import { BudgetItem, BudgetCategory } from "@shared/types/budget";
 
 interface BudgetItemListProps {
   items: BudgetItem[];
   onDeleteItem: (id: string) => void;
-  onEditItem?: (item: BudgetItem) => void;
+  onEditItem: (item: BudgetItem) => void;
 }
 
-export const BudgetItemList = ({
-  items,
-  onDeleteItem,
-  onEditItem,
-}: BudgetItemListProps) => {
-  const getCategoryStyle = (category: BudgetCategory): string => {
-    switch (category) {
-      case "income":
-        return "text-green-600 bg-green-100";
-      case "expense":
-        return "text-red-600 bg-red-100";
-      case "savings":
-        return "text-blue-600 bg-blue-100";
-      default:
-        return "text-gray-600 bg-gray-100";
-    }
-  };
+const categoryColor = (category: BudgetCategory): string => {
+  switch (category) {
+    case 'income': return 'text-income';
+    case 'expense': return 'text-expense';
+    case 'savings': return 'text-savings';
+  }
+};
+
+const amountPrefix = (category: BudgetCategory): string => {
+  return category === 'income' ? '+' : '−';
+};
+
+export const BudgetItemList = ({ items, onDeleteItem, onEditItem }: BudgetItemListProps) => {
+  if (items.length === 0) {
+    return (
+      <div className="border border-border rounded-xl px-6 py-12 text-center">
+        <p className="text-muted">No transactions yet</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="rounded-lg border border-gray-200">
-      <div className="bg-gray-50 py-3 px-4 border-b border-gray-200 grid grid-cols-12 font-medium text-sm text-gray-500">
-        <div className="col-span-4">Description</div>
-        <div className="col-span-2">Category</div>
-        <div className="col-span-2">Amount</div>
-        <div className="col-span-3">Date</div>
-        <div className="col-span-1 text-center">Action</div>
-      </div>
-      <ul className="divide-y divide-gray-200">
-        {items.map((item) => (
-          <li
-            key={item.id}
-            className="py-3 px-4 grid grid-cols-12 items-center"
-          >
-            <div className="col-span-4 text-gray-800">{item.description}</div>
-            <div className="col-span-2">
-              <span
-                className={`inline-flex rounded-full px-2 py-1 text-xs ${getCategoryStyle(
-                  item.category
-                )}`}
-              >
-                {item.category}
-              </span>
+    <ul className="border border-border rounded-xl divide-y divide-border">
+      {items.map((item) => (
+        <li key={item.id} className="group flex items-center justify-between px-5 py-4">
+          {/* Left: description + category pill */}
+          <div>
+            <p className="text-[15px] text-ink font-medium">{item.description}</p>
+            <div className={`flex items-center gap-1 mt-0.5 ${categoryColor(item.category)}`}>
+              <svg width="6" height="6" viewBox="0 0 6 6" fill="currentColor" aria-hidden="true">
+                <circle cx="3" cy="3" r="3" />
+              </svg>
+              <span className="text-xs font-medium capitalize">{item.category}</span>
             </div>
-            <div className="col-span-2 font-medium">
-              ${item.amount.toFixed(2)}
+          </div>
+
+          {/* Right: amount + date + actions */}
+          <div className="flex items-center gap-4">
+            <div className="text-right">
+              <p className={`text-[15px] font-semibold num ${categoryColor(item.category)}`}>
+                {amountPrefix(item.category)}${item.amount.toFixed(2)}
+              </p>
+              <p className="text-xs text-muted">
+                {new Date(item.date + 'T00:00:00').toLocaleDateString()}
+              </p>
             </div>
-            <div className="col-span-3 text-gray-500 text-sm">
-              {new Date(item.date).toLocaleDateString()}
-            </div>
-            <div className="col-span-1 flex justify-center items-center gap-1">
+
+            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-150">
               <button
-                onClick={() => onEditItem && onEditItem(item)}
-                className="text-blue-500 hover:text-blue-700 p-0.5 rounded-full hover:bg-blue-50"
-                aria-label="Edit item"
+                onClick={() => onEditItem(item)}
+                className="p-2 rounded-lg text-muted hover:text-ink hover:bg-border cursor-pointer transition-colors duration-150"
+                aria-label={`Edit ${item.description}`}
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                >
+                <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
                 </svg>
               </button>
               <button
                 onClick={() => onDeleteItem(item.id)}
-                className="text-red-500 hover:text-red-700 p-0.5 rounded-full hover:bg-red-50"
-                aria-label="Delete item"
+                className="p-2 rounded-lg text-muted hover:text-expense hover:bg-border cursor-pointer transition-colors duration-150"
+                aria-label={`Delete ${item.description}`}
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                    clipRule="evenodd"
-                  />
+                <svg width="15" height="15" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
                 </svg>
               </button>
             </div>
-          </li>
-        ))}
-      </ul>
-    </div>
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 };

--- a/src/components/BudgetSummary.tsx
+++ b/src/components/BudgetSummary.tsx
@@ -1,4 +1,4 @@
-import { BudgetSummary as BudgetSummaryType } from "../types/budget";
+import { BudgetSummary as BudgetSummaryType } from "@shared/types/budget";
 
 interface BudgetSummaryProps {
   summary: BudgetSummaryType;
@@ -7,38 +7,40 @@ interface BudgetSummaryProps {
 export const BudgetSummary = ({ summary }: BudgetSummaryProps) => {
   const { totalIncome, totalExpenses, totalSavings, balance } = summary;
 
+  const metrics = [
+    { label: 'Income', amount: totalIncome, color: 'text-income' },
+    { label: 'Expenses', amount: totalExpenses, color: 'text-expense' },
+    { label: 'Savings', amount: totalSavings, color: 'text-savings' },
+  ];
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-      <div className="rounded-lg p-4 border border-green-100 bg-green-50">
-        <h3 className="text-sm font-medium text-green-800">Income</h3>
-        <p className="text-xl font-bold text-green-600">
-          ${totalIncome.toFixed(2)}
-        </p>
-      </div>
-
-      <div className="rounded-lg p-4 border border-red-100 bg-red-50">
-        <h3 className="text-sm font-medium text-red-800">Expenses</h3>
-        <p className="text-xl font-bold text-red-600">
-          ${totalExpenses.toFixed(2)}
-        </p>
-      </div>
-
-      <div className="rounded-lg p-4 border border-blue-100 bg-blue-50">
-        <h3 className="text-sm font-medium text-blue-800">Savings</h3>
-        <p className="text-xl font-bold text-blue-600">
-          ${totalSavings.toFixed(2)}
-        </p>
-      </div>
-
-      <div className="rounded-lg p-4 border border-purple-100 bg-purple-50">
-        <h3 className="text-sm font-medium text-purple-800">Balance</h3>
-        <p
-          className={`text-xl font-bold ${
-            balance >= 0 ? "text-purple-600" : "text-red-600"
-          }`}
-        >
+    <div className="grid grid-cols-1 md:grid-cols-[3fr_2fr] gap-3 mb-8">
+      {/* Balance hero cell */}
+      <div className="bg-surface border border-border rounded-xl p-6 flex flex-col justify-between min-h-[160px]">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.1em] text-muted">
+          Net Balance
+        </span>
+        <span className={`text-5xl font-bold num ${balance >= 0 ? 'text-income' : 'text-expense'}`}>
           ${balance.toFixed(2)}
-        </p>
+        </span>
+        <span className="text-sm text-muted">income − expenses − savings</span>
+      </div>
+
+      {/* 3 stacked metric cards */}
+      <div className="grid grid-rows-3 gap-3">
+        {metrics.map((metric) => (
+          <div
+            key={metric.label}
+            className="bg-surface border border-border rounded-xl px-5 py-4 flex justify-between items-center"
+          >
+            <span className="text-[11px] font-semibold uppercase tracking-[0.1em] text-muted">
+              {metric.label}
+            </span>
+            <span className={`text-xl font-semibold num ${metric.color}`}>
+              ${metric.amount.toFixed(2)}
+            </span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/EditModal.tsx
+++ b/src/components/EditModal.tsx
@@ -1,0 +1,150 @@
+import { useState, useEffect } from "react";
+import { BudgetCategory, BudgetItem } from "@shared/types/budget";
+
+interface EditModalProps {
+  item: BudgetItem;
+  onSave: (updated: BudgetItem) => void;
+  onCancel: () => void;
+}
+
+export const EditModal = ({ item, onSave, onCancel }: EditModalProps) => {
+  const [type, setType] = useState<'income' | 'expense'>(
+    item.category === 'income' ? 'income' : 'expense'
+  );
+  const [expenseCategory, setExpenseCategory] = useState<'expense' | 'savings'>(
+    item.category === 'savings' ? 'savings' : 'expense'
+  );
+  const [amount, setAmount] = useState(item.amount.toString());
+  const [description, setDescription] = useState(item.description);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!description.trim() || !amount.trim() || parseFloat(amount) <= 0) return;
+
+    const category: BudgetCategory = type === 'income' ? 'income' : expenseCategory;
+    onSave({ ...item, description: description.trim(), amount: parseFloat(amount), category });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-ink/30"
+        onClick={onCancel}
+        aria-hidden="true"
+      />
+
+      {/* Modal card */}
+      <div
+        className="relative bg-surface border border-border rounded-xl p-6 w-full max-w-md mx-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-base font-semibold text-ink mb-6">Edit Transaction</h2>
+
+        <form onSubmit={handleSubmit}>
+          {/* Type segmented control */}
+          <div className="mb-5">
+            <label className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+              Type
+            </label>
+            <div className="flex gap-2">
+              {(['income', 'expense'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setType(t)}
+                  className={`flex-1 h-9 rounded-lg text-sm font-medium cursor-pointer transition-colors duration-150 ${
+                    type === t
+                      ? 'bg-ink text-surface'
+                      : 'border border-border text-muted hover:border-ink hover:text-ink'
+                  }`}
+                >
+                  {t === 'income' ? 'Income' : 'Expense'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Amount */}
+          <div className="mb-5">
+            <label htmlFor="edit-amount" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+              Amount
+            </label>
+            <div className="relative">
+              <span className="absolute inset-y-0 left-3 flex items-center text-muted pointer-events-none">$</span>
+              <input
+                id="edit-amount"
+                type="number"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="0.00"
+                step="0.01"
+                min="0.01"
+                required
+                className="w-full pl-8 pr-4 py-2.5 border border-border rounded-lg text-ink bg-transparent placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-ink num"
+              />
+            </div>
+          </div>
+
+          {/* Category — only when expense */}
+          {type === 'expense' && (
+            <div className="mb-5">
+              <label htmlFor="edit-category" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+                Category
+              </label>
+              <select
+                id="edit-category"
+                value={expenseCategory}
+                onChange={(e) => setExpenseCategory(e.target.value as 'expense' | 'savings')}
+                className="w-full py-2.5 px-3 border border-border rounded-lg text-ink bg-surface focus:outline-none focus:ring-1 focus:ring-ink cursor-pointer"
+              >
+                <option value="expense">General Expense</option>
+                <option value="savings">Savings</option>
+              </select>
+            </div>
+          )}
+
+          {/* Description */}
+          <div className="mb-6">
+            <label htmlFor="edit-description" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+              Description
+            </label>
+            <input
+              id="edit-description"
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What's this for?"
+              required
+              className="w-full py-2.5 px-3 border border-border rounded-lg text-ink bg-transparent placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-ink"
+            />
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex-1 min-h-[44px] border border-border text-muted rounded-lg font-medium hover:border-ink hover:text-ink cursor-pointer transition-colors duration-150"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="flex-1 min-h-[44px] bg-ink text-surface rounded-lg font-medium hover:opacity-90 cursor-pointer transition-opacity duration-150"
+            >
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,0 +1,33 @@
+import { BudgetCategory } from "@shared/types/budget";
+
+interface FilterBarProps {
+  active: BudgetCategory | 'all';
+  onChange: (cat: BudgetCategory | 'all') => void;
+}
+
+const filters: { label: string; value: BudgetCategory | 'all' }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Income', value: 'income' },
+  { label: 'Expense', value: 'expense' },
+  { label: 'Savings', value: 'savings' },
+];
+
+export const FilterBar = ({ active, onChange }: FilterBarProps) => {
+  return (
+    <div className="flex gap-2 mb-4">
+      {filters.map((filter) => (
+        <button
+          key={filter.value}
+          onClick={() => onChange(filter.value)}
+          className={`h-8 px-3 rounded-full text-sm font-medium cursor-pointer transition-colors duration-150 ${
+            active === filter.value
+              ? 'bg-ink text-surface'
+              : 'border border-border text-muted hover:border-ink hover:text-ink'
+          }`}
+        >
+          {filter.label}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,67 +1,31 @@
 @import "tailwindcss";
 
-/* Base styles for the app */
-body {
-  @apply bg-gray-50 text-gray-900 min-h-screen;
+@theme {
+  --color-canvas: #F5F2EC;
+  --color-surface: #FDFCFA;
+  --color-border: #E0DBCF;
+  --color-ink: #18170F;
+  --color-muted: #857F72;
+  --color-income: #0D7040;
+  --color-expense: #C1281A;
+  --color-savings: #1E52BB;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+*, *::before, *::after { box-sizing: border-box; }
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #F5F2EC;
+  color: #18170F;
+  min-height: 100vh;
+  margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
+.num { font-variant-numeric: tabular-nums; }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.3em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition-duration: 0.01ms !important; }
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,13 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    /* Path aliases */
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["./shared/*"]
+    }
   },
-  "include": ["src"]
+  "include": ["src", "shared"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,7 +18,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { resolve } from 'path'
 
-// https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),
-  tailwindcss(),
-  ],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: { '@shared': resolve(__dirname, './shared') }
+  }
 })


### PR DESCRIPTION
- Rewrite all components with Warm Ledger editorial design system (canvas #F5F2EC, Inter font, bento summary grid, hover-reveal row actions)
- Move types/utils/data to shared/ with @shared/* alias for future mobile sharing
- Implement Phase 4 edit functionality via EditModal (pre-filled, ESC to close, backdrop dismiss)
- Add FilterBar component for category filtering (list only, summary unaffected)
- Replace radio buttons with segmented type control in BudgetForm
- Remove Vite scaffold CSS junk from index.css; add @theme design tokens for Tailwind v4
- Scaffold mobile/ Expo app with React Navigation, screen stubs importing from @shared
- Add @types/node for vite.config.ts path alias; exclude .agents/ and mobile/ from ESLint