### PR TITLE
feat: Phase 13 — sort, date picker, CSV export, font refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,6 @@ docs/                     # Project standards — read before every task
 - Strict TypeScript: `noUnusedLocals`, `noUnusedParameters`
 
 ## Open TODOs
-- Phases 1–12c complete
-- Phase 10+ backlog: font change (S2 — replace Inter), mobile viewport E2E, CSV export, date picker on Quick Add, sort transactions, budget goals
+- Phases 1–13 complete
+- Remaining backlog: mobile viewport E2E, budget goals
 - Phase 12c note: EAS build step in mobile-ci.yml requires user to run `eas init` once + add `EAS_TOKEN` to GitHub secrets before activating

--- a/docs/Todos.md
+++ b/docs/Todos.md
@@ -851,6 +851,62 @@ Production-ready mobile app with realtime sync, performance targets met, and EAS
 
 ---
 
+# PHASE 13 — SORT, DATE PICKER & CSV EXPORT
+
+## Objective
+
+Web app backlog items: sort transactions, date picker on Quick Add, CSV export, and font refresh.
+
+---
+
+## Tasks
+
+### 13.1 — Sort Transactions (TDD) ✅ COMPLETE
+
+- [x] Add `SortOption` type to `shared/types/budget.ts`
+- [x] Add `sortBy` state + `SORT_FNS` lookup to `useBudget.ts`; spread before `.sort()` to avoid mutation
+- [x] Add `sortBy`/`onSortChange` required props to `FilterBar.tsx` + render `<select>` with 4 options
+- [x] Pass `sortBy`/`setSortBy` from `useBudget()` to `FilterBar` in `App.tsx`
+- [x] 5 new unit tests (filterBar.test.tsx) + 2 integration tests (budgetFlows.test.tsx)
+
+### 13.2 — Date Picker on Quick Add (TDD) ✅ COMPLETE
+
+- [x] Add `date` state (lazy `useState` init) to `BudgetForm.tsx`
+- [x] Add `<input type="date" />` labeled "Date"; use controlled state in submit; reset to today after submit
+- [x] 4 new unit tests (budgetForm.test.tsx)
+
+### 13.3 — CSV Export (TDD) ✅ COMPLETE
+
+- [x] Create `src/utils/csvExport.ts`: `generateCsv()` + `downloadCsv()` (DOM Blob API, web-only)
+- [x] Add Export CSV button to `App.tsx` header (ternary render when `budgetItems.length > 0`)
+- [x] Expose `budgetItems` in `useBudget()` return for export of unfiltered data
+- [x] 5 new unit tests (csvExport.test.ts)
+
+### 13.4 — Font Refresh (Design) ✅ COMPLETE
+
+- [x] Replace Inter with DM Sans in `index.html` Google Fonts link
+- [x] Update `--font-sans` token + body `font-family` in `index.css`
+- [x] Apply `style={{ fontFamily: 'var(--font-display)' }}` to `VistaFi` h1 in `App.tsx`
+- [x] Apply `style={{ fontFamily: 'var(--font-display)' }}` to `Quick Add` h2 in `BudgetForm.tsx`
+
+---
+
+## Testing (Phase 13)
+
+- 16 new tests total: 5 sort unit + 5 CSV unit + 4 date picker unit + 2 sort integration
+- All 104 tests pass (was 88 pre-Phase 13)
+
+---
+
+## Done Criteria (Phase 13) ✅
+
+1. Sort dropdown shows 4 options; default is Newest First (date-desc)
+2. Date input appears in Quick Add; backdated transactions saved with correct date
+3. Export CSV button appears when items exist; downloads valid CSV
+4. Body font is DM Sans; VistaFi h1 and Quick Add h2 render in Playfair Display
+
+---
+
 # MVP SUCCESS CRITERIA
 
 MVP is successful if:

--- a/docs/active-context.md
+++ b/docs/active-context.md
@@ -1,12 +1,14 @@
-# Active Context — Phase 12c: Polish, Realtime & Release
+# Active Context — Phase 13: Sort, Date Picker & CSV Export
 
 ## Context
 
-Phase 12b (Dashboard, Add, History, Edit screens) is merged to master. Phase 12c is the final
-mobile phase: Profile screen, Supabase Realtime sync, performance validation, EAS build config,
-and a mobile CI workflow.
+Phase 12c is complete and merged. Phase 13 addresses four backlog items from the web app:
+- Sort transactions (newest-first default, 4 options)
+- Date picker on Quick Add (replace hardcoded today's date)
+- CSV export (client-side Blob download)
+- Font refresh (DM Sans body, activate Playfair Display headings)
 
-Branch: `feature/phase-12c-polish-realtime-release`
+Branch: `feature/phase-13-sort-date-export`
 
 ---
 
@@ -14,31 +16,38 @@ Branch: `feature/phase-12c-polish-realtime-release`
 
 | # | Task | Status |
 |---|------|--------|
-| 12.8 RED | Failing tests — Profile Screen (profile.tsx) | complete |
-| 12.8 GREEN | Profile Screen implementation | complete |
-| 12.9 RED | Failing tests — Realtime subscription (useBudgetItems.ts) | complete |
-| 12.9 GREEN | useBudgetItems Realtime implementation | complete |
-| 12.10 | Performance audit (static checks + npm audit) | complete |
-| 12.11 | EAS build config + mobile CI workflow | complete |
+| 13.1 RED | Failing tests — Sort transactions (filterBar + integration) | in progress |
+| 13.1 GREEN | Sort implementation (useBudget, FilterBar, App) | pending |
+| 13.2 RED | Failing tests — Date picker (budgetForm.test.tsx) | pending |
+| 13.2 GREEN | Date picker implementation (BudgetForm.tsx) | pending |
+| 13.3 RED | Failing tests — CSV export (csvExport.test.ts) | pending |
+| 13.3 GREEN | CSV export implementation (csvExport.ts + App.tsx) | pending |
+| 13.4 | Font refresh — DM Sans + Playfair Display (no TDD) | pending |
 
 ---
 
 ## Architecture
 
-- `mobile/app/(tabs)/profile.tsx` — Profile screen: email display, sign out, biometrics toggle
-- `mobile/app/(tabs)/__tests__/profile.test.tsx` — 7 tests for profile screen
-- `mobile/src/hooks/useBudgetItems.ts` — adds Realtime channel subscription + cleanup
-- `mobile/src/hooks/__tests__/useBudgetItems.test.ts` — 3 existing + 5 new Realtime tests
-- `mobile/eas.json` — EAS build config (development/preview/production)
-- `.github/workflows/mobile-ci.yml` — type-check + unit tests on push/PR
+- `shared/types/budget.ts` — add `SortOption` type
+- `src/hooks/useBudget.ts` — add `sortBy` state + sort pipeline; expose `budgetItems`
+- `src/components/FilterBar.tsx` — add `sortBy`/`onSortChange` required props + sort select
+- `src/App.tsx` — pass sort props; add Export CSV button; apply display font to h1
+- `src/components/BudgetForm.tsx` — add `date` state + date input; apply display font to h2
+- `src/utils/csvExport.ts` — NEW: `generateCsv()` + `downloadCsv()`
+- `tests/unit/csvExport.test.ts` — NEW: 5 unit tests
+- `tests/unit/components/filterBar.test.tsx` — 6 existing renders updated + 5 new sort tests
+- `tests/unit/components/budgetForm.test.tsx` — 4 new date picker tests
+- `tests/integration/budgetFlows.test.tsx` — 2 new sort integration tests
+- `index.html` — replace Inter with DM Sans
+- `src/index.css` — update `--font-sans` + body font-family
 
 ## Key Rules Applied
-- TDD iron law: failing test FIRST, no production code without failing test
+- TDD iron law: failing test FIRST
+- Functional setState (`curr => ...`)
 - Ternary conditionals (not &&)
-- StyleSheet.create only (no inline objects)
-- 44pt touch targets; SafeAreaView on all screens
-- Warm Ledger colors
-- expo-haptics impactAsync(Light) on sign out
-- LocalAuthentication.hasHardwareAsync() guards biometrics toggle
-- No credentials in source code (biometric pref → AsyncStorage, not SecureStore)
-- All secrets injected via GitHub Actions secrets only
+- Lazy useState init for date field
+- 44px min-height on all interactive elements
+- aria-labels on all controls
+- cursor-pointer on all clickable elements
+- Logic in hooks (sortBy state in useBudget, not FilterBar)
+- Readonly TypeScript props interfaces

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>VistaFi</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Playfair+Display:wght@400;600&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/shared/types/budget.ts
+++ b/shared/types/budget.ts
@@ -14,3 +14,5 @@ export interface BudgetSummary {
     totalSavings: number;
     balance: number;
 }
+
+export type SortOption = 'date-desc' | 'date-asc' | 'amount-desc' | 'amount-asc';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,14 +8,18 @@ import { LoginPage } from './pages/LoginPage';
 import { SignupPage } from './pages/SignupPage';
 import { useAuth } from './context/AuthContext';
 import { useBudget } from './hooks/useBudget';
+import { generateCsv, downloadCsv } from './utils/csvExport';
 
 function BudgetApp() {
   const {
+    budgetItems,
     itemToEdit,
     filterCategory,
     setFilterCategory,
     searchQuery,
     setSearchQuery,
+    sortBy,
+    setSortBy,
     filteredItems,
     summary,
     isLoading,
@@ -50,17 +54,29 @@ function BudgetApp() {
       <div className="max-w-5xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
         <header className="mb-8 flex items-start justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-ink">VistaFi</h1>
+            <h1 className="text-2xl font-bold text-ink" style={{ fontFamily: 'var(--font-display)' }}>VistaFi</h1>
             <p className="text-sm text-muted">Simple Budget Planner</p>
           </div>
-          <button
-            type="button"
-            onClick={signOut}
-            aria-label="Sign out"
-            className="min-h-[44px] px-4 text-sm text-muted hover:text-ink cursor-pointer transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink rounded-lg"
-          >
-            Sign out
-          </button>
+          <div className="flex items-center gap-2">
+            {budgetItems.length > 0 ? (
+              <button
+                type="button"
+                onClick={() => downloadCsv('vistafi-transactions.csv', generateCsv(budgetItems))}
+                aria-label="Export transactions as CSV"
+                className="min-h-[44px] px-4 text-sm text-muted hover:text-ink cursor-pointer transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink rounded-lg"
+              >
+                Export CSV
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={signOut}
+              aria-label="Sign out"
+              className="min-h-[44px] px-4 text-sm text-muted hover:text-ink cursor-pointer transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink rounded-lg"
+            >
+              Sign out
+            </button>
+          </div>
         </header>
 
         <BudgetSummary summary={summary} />
@@ -73,6 +89,8 @@ function BudgetApp() {
               onChange={setFilterCategory}
               searchQuery={searchQuery}
               onSearchChange={setSearchQuery}
+              sortBy={sortBy}
+              onSortChange={setSortBy}
             />
             <BudgetItemList
               items={filteredItems}

--- a/src/components/BudgetForm.tsx
+++ b/src/components/BudgetForm.tsx
@@ -11,6 +11,7 @@ export const BudgetForm = ({ onAddItem }: Readonly<BudgetFormProps>) => {
   const [expenseCategory, setExpenseCategory] = useState<'expense' | 'savings'>('expense');
   const [amount, setAmount] = useState('');
   const [description, setDescription] = useState('');
+  const [date, setDate] = useState(() => new Date().toISOString().split('T')[0]);
   const [showAdded, setShowAdded] = useState(false);
 
   useEffect(() => {
@@ -29,7 +30,7 @@ export const BudgetForm = ({ onAddItem }: Readonly<BudgetFormProps>) => {
       description: description.trim(),
       amount: parseFloat(amount),
       category,
-      date: new Date().toISOString().split('T')[0],
+      date,
     };
 
     onAddItem(newItem);
@@ -37,12 +38,13 @@ export const BudgetForm = ({ onAddItem }: Readonly<BudgetFormProps>) => {
     setAmount('');
     setType('expense');
     setExpenseCategory('expense');
+    setDate(new Date().toISOString().split('T')[0]);
     setShowAdded(true);
   };
 
   return (
     <form onSubmit={handleSubmit} className="bg-surface border border-border rounded-xl p-6">
-      <h2 className="text-base font-semibold text-ink mb-6">Quick Add</h2>
+      <h2 className="text-base font-semibold text-ink mb-6" style={{ fontFamily: 'var(--font-display)' }}>Quick Add</h2>
 
       {/* Type segmented control */}
       <div className="mb-5">
@@ -107,7 +109,7 @@ export const BudgetForm = ({ onAddItem }: Readonly<BudgetFormProps>) => {
       ) : null}
 
       {/* Description */}
-      <div className="mb-6">
+      <div className="mb-5">
         <label htmlFor="description" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
           Description
         </label>
@@ -119,6 +121,21 @@ export const BudgetForm = ({ onAddItem }: Readonly<BudgetFormProps>) => {
           placeholder="What's this for?"
           required
           className="w-full min-h-[44px] py-2.5 px-3 border border-border rounded-lg text-ink bg-transparent placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-ink"
+        />
+      </div>
+
+      {/* Date */}
+      <div className="mb-6">
+        <label htmlFor="date" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+          Date
+        </label>
+        <input
+          id="date"
+          type="date"
+          value={date}
+          onChange={e => setDate(e.target.value)}
+          required
+          className="w-full min-h-[44px] py-2.5 px-3 border border-border rounded-lg text-ink bg-transparent focus:outline-none focus:ring-1 focus:ring-ink"
         />
       </div>
 

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,10 +1,12 @@
-import { BudgetCategory } from "@shared/types/budget";
+import { BudgetCategory, SortOption } from "@shared/types/budget";
 
 interface FilterBarProps {
   active: BudgetCategory | 'all';
   onChange: (cat: BudgetCategory | 'all') => void;
   searchQuery: string;
   onSearchChange: (q: string) => void;
+  sortBy: SortOption;
+  onSortChange: (sort: SortOption) => void;
 }
 
 const filters: { label: string; value: BudgetCategory | 'all' }[] = [
@@ -14,9 +16,9 @@ const filters: { label: string; value: BudgetCategory | 'all' }[] = [
   { label: 'Savings', value: 'savings' },
 ];
 
-export const FilterBar = ({ active, onChange, searchQuery, onSearchChange }: Readonly<FilterBarProps>) => {
+export const FilterBar = ({ active, onChange, searchQuery, onSearchChange, sortBy, onSortChange }: Readonly<FilterBarProps>) => {
   return (
-    <div className="flex justify-between gap-4 mb-4">
+    <div className="flex flex-wrap justify-between gap-4 mb-4">
       <div className="flex gap-2">
         {filters.map((filter) => (
           <button
@@ -32,7 +34,20 @@ export const FilterBar = ({ active, onChange, searchQuery, onSearchChange }: Rea
           </button>
         ))}
       </div>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-2">
+        <label htmlFor="sort-transactions" className="sr-only">Sort transactions</label>
+        <select
+          id="sort-transactions"
+          value={sortBy}
+          onChange={e => onSortChange(e.target.value as SortOption)}
+          aria-label="Sort transactions"
+          className="min-h-[44px] px-3 rounded-full text-sm border border-border text-ink bg-surface focus:outline-none focus:border-ink transition-colors duration-150 cursor-pointer"
+        >
+          <option value="date-desc">Newest First</option>
+          <option value="date-asc">Oldest First</option>
+          <option value="amount-desc">Amount High{'\u2013'}Low</option>
+          <option value="amount-asc">Amount Low{'\u2013'}High</option>
+        </select>
         <label htmlFor="search-transactions" className="sr-only">Search transactions</label>
         <input
           id="search-transactions"

--- a/src/hooks/useBudget.ts
+++ b/src/hooks/useBudget.ts
@@ -1,13 +1,21 @@
 import { useState, useEffect } from 'react';
-import { BudgetItem, BudgetCategory } from '@shared/types/budget';
+import { BudgetItem, BudgetCategory, SortOption } from '@shared/types/budget';
 import { calculateBudgetSummary } from '@shared/utils/budgetUtils';
 import { fetchItems, addItem, updateItem, deleteItem } from '../services/budgetService';
+
+const SORT_FNS: Record<SortOption, (a: BudgetItem, b: BudgetItem) => number> = {
+  'date-desc':   (a, b) => b.date.localeCompare(a.date),
+  'date-asc':    (a, b) => a.date.localeCompare(b.date),
+  'amount-desc': (a, b) => b.amount - a.amount,
+  'amount-asc':  (a, b) => a.amount - b.amount,
+};
 
 export function useBudget() {
   const [budgetItems, setBudgetItems] = useState<BudgetItem[]>([]);
   const [itemToEdit, setItemToEdit] = useState<BudgetItem | null>(null);
   const [filterCategory, setFilterCategory] = useState<BudgetCategory | 'all'>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<SortOption>('date-desc');
   const [isLoading, setIsLoading] = useState(true);
   const [dataError, setDataError] = useState<string | null>(null);
 
@@ -48,16 +56,20 @@ export function useBudget() {
 
   const summary = calculateBudgetSummary(budgetItems);
 
-  const filteredItems = budgetItems
+  const filteredItems = [...budgetItems
     .filter(item => filterCategory === 'all' || item.category === filterCategory)
-    .filter(item => item.description.toLowerCase().includes(searchQuery.toLowerCase().trim()));
+    .filter(item => item.description.toLowerCase().includes(searchQuery.toLowerCase().trim()))
+  ].sort(SORT_FNS[sortBy]);
 
   return {
+    budgetItems,
     itemToEdit,
     filterCategory,
     setFilterCategory,
     searchQuery,
     setSearchQuery,
+    sortBy,
+    setSortBy,
     filteredItems,
     summary,
     isLoading,

--- a/src/index.css
+++ b/src/index.css
@@ -9,14 +9,14 @@
   --color-income: #0D7040;
   --color-expense: #C1281A;
   --color-savings: #1E52BB;
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
   --font-display: 'Playfair Display', Georgia, serif;
 }
 
 *, *::before, *::after { box-sizing: border-box; }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
   background-color: #F5F2EC;
   color: #18170F;
   min-height: 100vh;

--- a/src/utils/csvExport.ts
+++ b/src/utils/csvExport.ts
@@ -1,0 +1,22 @@
+import type { BudgetItem } from '@shared/types/budget';
+
+export function generateCsv(items: BudgetItem[]): string {
+  const header = 'Date,Description,Category,Amount';
+  const rows = items.map(item => {
+    const desc = item.description.includes(',')
+      ? `"${item.description}"`
+      : item.description;
+    return `${item.date},${desc},${item.category},${item.amount}`;
+  });
+  return [header, ...rows].join('\n');
+}
+
+export function downloadCsv(filename: string, content: string): void {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/tests/integration/budgetFlows.test.tsx
+++ b/tests/integration/budgetFlows.test.tsx
@@ -130,6 +130,34 @@ describe('Budget CRUD flows', () => {
   })
 })
 
+describe('Sort flows', () => {
+  it('should display items newest-first by default (item with latest date appears first)', async () => {
+    // Given — mockBudgetItems has Utilities on 2023-11-15 (latest date)
+    render(<App />)
+    await screen.findByText('Groceries')
+
+    // When — default sort is date-desc (newest first)
+    const listItems = screen.getAllByRole('listitem')
+
+    // Then — first item in list should be the one with latest date (Utilities 2023-11-15)
+    expect(listItems[0]).toHaveTextContent('Utilities')
+  })
+
+  it('should place highest-amount item first after switching sort to "amount-desc"', async () => {
+    // Given — mockBudgetItems has Monthly Salary at $4000 (highest)
+    const user = userEvent.setup()
+    render(<App />)
+    await screen.findByText('Groceries')
+
+    // When — change sort to Amount High–Low
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Sort transactions' }), 'amount-desc')
+
+    // Then — first item should be Monthly Salary ($4000)
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems[0]).toHaveTextContent('Monthly Salary')
+  })
+})
+
 describe('Filter and search flows', () => {
   it('should filter by category and leave summary unchanged', async () => {
     // Given

--- a/tests/unit/components/budgetForm.test.tsx
+++ b/tests/unit/components/budgetForm.test.tsx
@@ -98,4 +98,49 @@ describe('BudgetForm', () => {
     // Then
     expect(screen.getByRole('status')).toHaveTextContent(/transaction added/i)
   })
+
+  // --- Date picker tests (Task 13.2) ---
+
+  it('should render a date input labeled "Date"', () => {
+    // Given / When
+    render(<BudgetForm onAddItem={vi.fn()} />)
+    // Then
+    expect(screen.getByLabelText('Date')).toBeInTheDocument()
+  })
+
+  it('should render date input with type="date"', () => {
+    // Given / When
+    render(<BudgetForm onAddItem={vi.fn()} />)
+    // Then
+    const dateInput = screen.getByLabelText('Date') as HTMLInputElement
+    expect(dateInput.type).toBe('date')
+  })
+
+  it('should default date input to today\'s ISO date string (YYYY-MM-DD)', () => {
+    // Given
+    const today = new Date().toISOString().split('T')[0]
+    // When
+    render(<BudgetForm onAddItem={vi.fn()} />)
+    // Then
+    const dateInput = screen.getByLabelText('Date') as HTMLInputElement
+    expect(dateInput.value).toBe(today)
+  })
+
+  it('should submit item with the date shown in the date input (not hardcoded Date.now())', async () => {
+    // Given
+    const onAddItem = vi.fn()
+    const user = userEvent.setup()
+    render(<BudgetForm onAddItem={onAddItem} />)
+    const dateInput = screen.getByLabelText('Date')
+    // When — change date to a past date
+    await user.clear(dateInput)
+    await user.type(dateInput, '2023-06-15')
+    await user.type(screen.getByLabelText(/amount/i), '250')
+    await user.type(screen.getByLabelText(/description/i), 'Backdated Payment')
+    await user.click(screen.getByRole('button', { name: /add transaction/i }))
+    // Then — submitted item date must match what was typed, not today
+    expect(onAddItem).toHaveBeenCalledOnce()
+    const item = onAddItem.mock.calls[0][0]
+    expect(item.date).toBe('2023-06-15')
+  })
 })

--- a/tests/unit/components/filterBar.test.tsx
+++ b/tests/unit/components/filterBar.test.tsx
@@ -16,6 +16,8 @@ describe('FilterBar', () => {
         onChange={onChange}
         searchQuery=""
         onSearchChange={onSearchChange}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
       />
     )
     // Then
@@ -34,6 +36,8 @@ describe('FilterBar', () => {
         onChange={onChange}
         searchQuery=""
         onSearchChange={onSearchChange}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
       />
     )
     // When
@@ -53,6 +57,8 @@ describe('FilterBar', () => {
         onChange={onChange}
         searchQuery=""
         onSearchChange={onSearchChange}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
       />
     )
     // When
@@ -69,6 +75,8 @@ describe('FilterBar', () => {
         onChange={vi.fn()}
         searchQuery="rent"
         onSearchChange={vi.fn()}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
       />
     )
     // Then
@@ -83,6 +91,8 @@ describe('FilterBar', () => {
         onChange={vi.fn()}
         searchQuery=""
         onSearchChange={vi.fn()}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
       />
     )
     // Then
@@ -99,11 +109,103 @@ describe('FilterBar', () => {
         onChange={vi.fn()}
         searchQuery="rent"
         onSearchChange={onSearchChange}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
       />
     )
     // When
     await user.click(screen.getByRole('button', { name: 'Clear search' }))
     // Then
     expect(onSearchChange).toHaveBeenCalledWith('')
+  })
+
+  // --- Sort tests (Task 13.1) ---
+
+  it('should render a sort select with aria-label "Sort transactions"', () => {
+    // Given / When
+    render(
+      <FilterBar
+        active="all"
+        onChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
+      />
+    )
+    // Then
+    expect(screen.getByRole('combobox', { name: 'Sort transactions' })).toBeInTheDocument()
+  })
+
+  it('should render sort select with exactly 4 options: Newest First, Oldest First, Amount High–Low, Amount Low–High', () => {
+    // Given / When
+    render(
+      <FilterBar
+        active="all"
+        onChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
+      />
+    )
+    // Then
+    const select = screen.getByRole('combobox', { name: 'Sort transactions' })
+    const options = Array.from((select as HTMLSelectElement).options).map(o => o.text)
+    expect(options).toEqual(['Newest First', 'Oldest First', 'Amount High\u2013Low', 'Amount Low\u2013High'])
+  })
+
+  it('should have default selected value of "date-desc"', () => {
+    // Given / When
+    render(
+      <FilterBar
+        active="all"
+        onChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
+      />
+    )
+    // Then
+    const select = screen.getByRole('combobox', { name: 'Sort transactions' }) as HTMLSelectElement
+    expect(select.value).toBe('date-desc')
+  })
+
+  it('should call onSortChange with the selected value when sort select changes', async () => {
+    // Given
+    const onSortChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FilterBar
+        active="all"
+        onChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        sortBy="date-desc"
+        onSortChange={onSortChange}
+      />
+    )
+    // When
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Sort transactions' }), 'amount-desc')
+    // Then
+    expect(onSortChange).toHaveBeenCalledWith('amount-desc')
+  })
+
+  it('should have min-height of 44px on the sort select (touch target rule)', () => {
+    // Given / When
+    render(
+      <FilterBar
+        active="all"
+        onChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        sortBy="date-desc"
+        onSortChange={vi.fn()}
+      />
+    )
+    // Then
+    const select = screen.getByRole('combobox', { name: 'Sort transactions' })
+    expect(select).toHaveClass('min-h-[44px]')
   })
 })

--- a/tests/unit/csvExport.test.ts
+++ b/tests/unit/csvExport.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { generateCsv } from '../../src/utils/csvExport'
+import type { BudgetItem } from '@shared/types/budget'
+
+const makeItem = (overrides: Partial<BudgetItem> = {}): BudgetItem => ({
+  id: '1',
+  description: 'Test',
+  amount: 100,
+  category: 'expense',
+  date: '2023-11-01',
+  ...overrides,
+})
+
+describe('generateCsv', () => {
+  it('should return only the header row when given an empty array', () => {
+    // Given / When
+    const result = generateCsv([])
+    // Then
+    expect(result).toBe('Date,Description,Category,Amount')
+  })
+
+  it('should return header plus one data row with fields in order: date, description, category, amount', () => {
+    // Given
+    const item = makeItem({ date: '2023-11-05', description: 'Rent', category: 'expense', amount: 1500 })
+    // When
+    const result = generateCsv([item])
+    // Then
+    const lines = result.split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toBe('Date,Description,Category,Amount')
+    expect(lines[1]).toBe('2023-11-05,Rent,expense,1500')
+  })
+
+  it('should output amount as a plain number without currency symbol', () => {
+    // Given
+    const item = makeItem({ amount: 5000 })
+    // When
+    const result = generateCsv([item])
+    // Then
+    const dataRow = result.split('\n')[1]
+    expect(dataRow).toContain('5000')
+    expect(dataRow).not.toContain('$')
+  })
+
+  it('should wrap description containing a comma in double quotes', () => {
+    // Given
+    const item = makeItem({ description: 'Food, drink', amount: 50, date: '2023-11-10', category: 'expense' })
+    // When
+    const result = generateCsv([item])
+    // Then
+    const dataRow = result.split('\n')[1]
+    expect(dataRow).toBe('2023-11-10,"Food, drink",expense,50')
+  })
+
+  it('should output category as lowercase as stored', () => {
+    // Given
+    const income = makeItem({ category: 'income', description: 'Salary', amount: 4000, date: '2023-11-01' })
+    const savings = makeItem({ category: 'savings', description: 'Fund', amount: 500, date: '2023-11-02' })
+    // When
+    const result = generateCsv([income, savings])
+    // Then
+    const lines = result.split('\n')
+    expect(lines[1]).toContain('income')
+    expect(lines[2]).toContain('savings')
+  })
+})


### PR DESCRIPTION
13.1: Add SortOption type; useBudget sort pipeline (date/amount asc/desc); FilterBar sort <select> with 4 options + required sortBy/onSortChange props.

13.2: BudgetForm date state (lazy useState); <input type="date" />; uses controlled state for submit; resets to today after add.

13.3: csvExport.ts (generateCsv + downloadCsv, web-only Blob API); Export CSV button in App header (ternary, only when items exist); budgetItems exposed from useBudget return for unfiltered export.

13.4: DM Sans replaces Inter (index.html + index.css); Playfair Display activated on VistaFi h1 (App.tsx) and Quick Add h2 (BudgetForm.tsx).

Tests: 16 new tests (5 sort unit, 5 CSV unit, 4 date picker unit, 2 sort integration); 104/104 passing. Lint clean. Build clean.