### PR TITLE
feat: Phase 14 — budget goals + mobile viewport E2E

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,6 @@ docs/                     # Project standards — read before every task
 - Strict TypeScript: `noUnusedLocals`, `noUnusedParameters`
 
 ## Open TODOs
-- Phases 1–13 complete
-- Remaining backlog: mobile viewport E2E, budget goals
+- Phases 1–14 complete
+- Remaining backlog: budget goal delete UI (currently done via upsert with null), advanced analytics
 - Phase 12c note: EAS build step in mobile-ci.yml requires user to run `eas init` once + add `EAS_TOKEN` to GitHub secrets before activating

--- a/docs/Todos.md
+++ b/docs/Todos.md
@@ -907,6 +907,32 @@ Web app backlog items: sort transactions, date picker on Quick Add, CSV export, 
 
 ---
 
+# Phase 14 — Budget Goals + Mobile Viewport E2E
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 14.1a | `calculateCurrentMonthSummary` util + `BudgetGoal` type | ✅ |
+| 14.1b | `goalService.ts` (fetchGoals / upsertGoal / deleteGoal) | ✅ |
+| 14.1c | `BudgetSummary` — goals + currentMonthSummary props + progress bars | ✅ |
+| 14.1d | `GoalModal` — 3-input modal for monthly targets | ✅ |
+| 14.1e | `useGoals` hook + Goals button in App + migration SQL | ✅ |
+| 14.2 | Mobile viewport E2E — 4 Playwright tests (Pixel 5) | ✅ |
+
+## Done Criteria (Phase 14) ✅
+
+1. `calculateCurrentMonthSummary` filters items by month prefix and delegates to `calculateBudgetSummary`
+2. `BudgetGoal` interface exported from `shared/types/budget.ts`
+3. `goalService.ts` maps `target_amount` → `targetAmount`; upserts on `user_id,category` conflict
+4. `BudgetSummary` shows a `role="progressbar"` with `aria-label` for each category that has a goal
+5. `GoalModal` accepts 3 number inputs; empty inputs produce `null` targetAmount in onSave payload
+6. Goals button in header opens `GoalModal`; Cancel/Save dismiss it
+7. `tests/e2e/mobile.spec.ts` runs 4 tests against Pixel 5 viewport
+8. All 121 unit/integration tests pass; lint clean; build clean
+
+---
+
 # MVP SUCCESS CRITERIA
 
 MVP is successful if:

--- a/docs/active-context.md
+++ b/docs/active-context.md
@@ -1,14 +1,12 @@
-# Active Context — Phase 13: Sort, Date Picker & CSV Export
+# Active Context — Phase 14: Budget Goals + Mobile Viewport E2E
 
 ## Context
 
-Phase 12c is complete and merged. Phase 13 addresses four backlog items from the web app:
-- Sort transactions (newest-first default, 4 options)
-- Date picker on Quick Add (replace hardcoded today's date)
-- CSV export (client-side Blob download)
-- Font refresh (DM Sans body, activate Playfair Display headings)
+Phase 13 is complete and merged. Phase 14 delivers two backlog items:
+1. Budget goals — per-category monthly targets with progress bars in BudgetSummary
+2. Mobile viewport E2E — 4 Playwright tests at Pixel 5 viewport
 
-Branch: `feature/phase-13-sort-date-export`
+Branch: `feature/phase-14-budget-goals-mobile-e2e`
 
 ---
 
@@ -16,38 +14,55 @@ Branch: `feature/phase-13-sort-date-export`
 
 | # | Task | Status |
 |---|------|--------|
-| 13.1 RED | Failing tests — Sort transactions (filterBar + integration) | in progress |
-| 13.1 GREEN | Sort implementation (useBudget, FilterBar, App) | pending |
-| 13.2 RED | Failing tests — Date picker (budgetForm.test.tsx) | pending |
-| 13.2 GREEN | Date picker implementation (BudgetForm.tsx) | pending |
-| 13.3 RED | Failing tests — CSV export (csvExport.test.ts) | pending |
-| 13.3 GREEN | CSV export implementation (csvExport.ts + App.tsx) | pending |
-| 13.4 | Font refresh — DM Sans + Playfair Display (no TDD) | pending |
+| 14.1a RED | Failing tests — calculateCurrentMonthSummary (budgetUtils.test.ts, 3 new tests) | pending |
+| 14.1b RED | Failing tests — goalService (tests/unit/services/goalService.test.ts, 5 new tests) | pending |
+| 14.1c RED | Failing tests — BudgetSummary with goals/progress props (4 new + update 6 existing) | pending |
+| 14.1d RED | Failing tests — GoalModal component (5 new tests) | pending |
+| 14.1a GREEN | calculateCurrentMonthSummary in shared/utils/budgetUtils.ts | pending |
+| 14.1a GREEN | BudgetGoal type in shared/types/budget.ts | pending |
+| 14.1b GREEN | src/services/goalService.ts | pending |
+| 14.1c GREEN | Update src/components/BudgetSummary.tsx (goals + progress bars) | pending |
+| 14.1d GREEN | Create src/components/GoalModal.tsx | pending |
+| 14.1e GREEN | Create src/hooks/useGoals.ts | pending |
+| 14.1e GREEN | Create src/lib/migrations/002_budget_goals.sql | pending |
+| 14.1e GREEN | Update src/App.tsx (Goals button + GoalModal + useGoals) | pending |
+| 14.2 | Mobile viewport E2E (playwright.config.ts + tests/e2e/mobile.spec.ts) | pending |
 
 ---
 
 ## Architecture
 
-- `shared/types/budget.ts` — add `SortOption` type
-- `src/hooks/useBudget.ts` — add `sortBy` state + sort pipeline; expose `budgetItems`
-- `src/components/FilterBar.tsx` — add `sortBy`/`onSortChange` required props + sort select
-- `src/App.tsx` — pass sort props; add Export CSV button; apply display font to h1
-- `src/components/BudgetForm.tsx` — add `date` state + date input; apply display font to h2
-- `src/utils/csvExport.ts` — NEW: `generateCsv()` + `downloadCsv()`
-- `tests/unit/csvExport.test.ts` — NEW: 5 unit tests
-- `tests/unit/components/filterBar.test.tsx` — 6 existing renders updated + 5 new sort tests
-- `tests/unit/components/budgetForm.test.tsx` — 4 new date picker tests
-- `tests/integration/budgetFlows.test.tsx` — 2 new sort integration tests
-- `index.html` — replace Inter with DM Sans
-- `src/index.css` — update `--font-sans` + body font-family
+### New Files
+- `src/services/goalService.ts` — fetchGoals / upsertGoal / deleteGoal (Supabase)
+- `src/hooks/useGoals.ts` — goals state, handleSetGoal, handleDeleteGoal
+- `src/components/GoalModal.tsx` — 3-input modal (income/expense/savings targets)
+- `src/lib/migrations/002_budget_goals.sql` — budget_goals table + RLS
+- `tests/unit/services/goalService.test.ts` — 5 service tests
+- `tests/unit/components/goalModal.test.tsx` — 5 component tests
+- `tests/e2e/mobile.spec.ts` — 4 Playwright mobile viewport tests
+
+### Modified Files
+- `shared/types/budget.ts` — add BudgetGoal interface
+- `shared/utils/budgetUtils.ts` — add calculateCurrentMonthSummary()
+- `src/components/BudgetSummary.tsx` — add goals + currentMonthSummary props + progress bars
+- `src/App.tsx` — add Goals button, GoalModal, useGoals, calculateCurrentMonthSummary
+- `tests/unit/budgetUtils.test.ts` — 3 new calculateCurrentMonthSummary tests
+- `tests/unit/components/budgetSummary.test.tsx` — update 6 + add 4 tests
+- `playwright.config.ts` — add mobile-chrome project
+
+### Supabase Table
+```sql
+budget_goals (id, user_id, category, target_amount, created_at)
+unique(user_id, category) — upsert on conflict
+RLS: auth.uid() = user_id
+```
 
 ## Key Rules Applied
 - TDD iron law: failing test FIRST
 - Functional setState (`curr => ...`)
 - Ternary conditionals (not &&)
-- Lazy useState init for date field
+- Progress bars: role="progressbar", aria-label, aria-valuenow, aria-valuemin={0}, aria-valuemax={100}
 - 44px min-height on all interactive elements
 - aria-labels on all controls
-- cursor-pointer on all clickable elements
-- Logic in hooks (sortBy state in useBudget, not FilterBar)
 - Readonly TypeScript props interfaces
+- No console.log anywhere

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
   ],
   webServer: {
     command: 'npm run preview',

--- a/shared/types/budget.ts
+++ b/shared/types/budget.ts
@@ -16,3 +16,9 @@ export interface BudgetSummary {
 }
 
 export type SortOption = 'date-desc' | 'date-asc' | 'amount-desc' | 'amount-asc';
+
+export interface BudgetGoal {
+  id: string;
+  category: BudgetCategory;
+  targetAmount: number;
+}

--- a/shared/utils/budgetUtils.ts
+++ b/shared/utils/budgetUtils.ts
@@ -18,6 +18,15 @@ export const calculateBudgetSummary = (items: BudgetItem[]): BudgetSummary => {
     return { totalIncome, totalExpenses, totalSavings, balance };
 };
 
+export const calculateCurrentMonthSummary = (
+  items: BudgetItem[],
+  month: string = new Date().toISOString().slice(0, 7),
+): BudgetSummary => {
+  return calculateBudgetSummary(
+    items.filter(item => item.date.startsWith(month))
+  );
+};
+
 export const generateId = (): string => {
     return Math.random().toString(36).substring(2, 9);
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,14 @@ import { BudgetItemList } from './components/BudgetItemList';
 import { BudgetSummary } from './components/BudgetSummary';
 import { FilterBar } from './components/FilterBar';
 import { EditModal } from './components/EditModal';
+import { GoalModal } from './components/GoalModal';
 import { LoginPage } from './pages/LoginPage';
 import { SignupPage } from './pages/SignupPage';
 import { useAuth } from './context/AuthContext';
 import { useBudget } from './hooks/useBudget';
+import { useGoals } from './hooks/useGoals';
 import { generateCsv, downloadCsv } from './utils/csvExport';
+import { calculateCurrentMonthSummary } from '@shared/utils/budgetUtils';
 
 function BudgetApp() {
   const {
@@ -30,6 +33,10 @@ function BudgetApp() {
     handleSaveEdit,
     handleCancelEdit,
   } = useBudget();
+
+  const { goals, handleSetGoal, handleDeleteGoal } = useGoals();
+  const [goalsOpen, setGoalsOpen] = useState(false);
+  const currentMonthSummary = calculateCurrentMonthSummary(budgetItems);
 
   const { signOut } = useAuth();
 
@@ -70,6 +77,14 @@ function BudgetApp() {
             ) : null}
             <button
               type="button"
+              onClick={() => setGoalsOpen(true)}
+              aria-label="Set monthly goals"
+              className="min-h-[44px] px-4 text-sm text-muted hover:text-ink cursor-pointer transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink rounded-lg"
+            >
+              Goals
+            </button>
+            <button
+              type="button"
               onClick={signOut}
               aria-label="Sign out"
               className="min-h-[44px] px-4 text-sm text-muted hover:text-ink cursor-pointer transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink rounded-lg"
@@ -79,7 +94,7 @@ function BudgetApp() {
           </div>
         </header>
 
-        <BudgetSummary summary={summary} />
+        <BudgetSummary summary={summary} goals={goals} currentMonthSummary={currentMonthSummary} />
 
         <div className="grid grid-cols-1 md:grid-cols-[320px_1fr] gap-6 mt-8">
           <BudgetForm onAddItem={handleAddItem} />
@@ -106,6 +121,26 @@ function BudgetApp() {
           item={itemToEdit}
           onSave={handleSaveEdit}
           onCancel={handleCancelEdit}
+        />
+      ) : null}
+
+      {goalsOpen ? (
+        <GoalModal
+          goals={goals}
+          onSave={(updates) => {
+            updates.forEach(u => {
+              if (u.targetAmount !== null) {
+                handleSetGoal(u.category, u.targetAmount).catch(() => undefined);
+              } else {
+                const existing = goals.find(g => g.category === u.category);
+                if (existing) {
+                  handleDeleteGoal(existing.id).catch(() => undefined);
+                }
+              }
+            });
+            setGoalsOpen(false);
+          }}
+          onCancel={() => setGoalsOpen(false)}
         />
       ) : null}
     </div>

--- a/src/components/BudgetSummary.tsx
+++ b/src/components/BudgetSummary.tsx
@@ -1,16 +1,39 @@
-import { BudgetSummary as BudgetSummaryType } from "@shared/types/budget";
+import { BudgetSummary as BudgetSummaryType, BudgetGoal } from "@shared/types/budget";
 
 interface BudgetSummaryProps {
   summary: BudgetSummaryType;
+  goals: BudgetGoal[];
+  currentMonthSummary: BudgetSummaryType;
 }
 
-export const BudgetSummary = ({ summary }: Readonly<BudgetSummaryProps>) => {
+export const BudgetSummary = ({ summary, goals, currentMonthSummary }: Readonly<BudgetSummaryProps>) => {
   const { totalIncome, totalExpenses, totalSavings, balance } = summary;
 
   const metrics = [
-    { label: 'Income', amount: totalIncome, color: 'text-income' },
-    { label: 'Expenses', amount: totalExpenses, color: 'text-expense' },
-    { label: 'Savings', amount: totalSavings, color: 'text-savings' },
+    {
+      label: 'Income',
+      amount: totalIncome,
+      color: 'text-income',
+      barColor: 'bg-income',
+      currentAmount: currentMonthSummary.totalIncome,
+      goalCategory: 'income' as const,
+    },
+    {
+      label: 'Expenses',
+      amount: totalExpenses,
+      color: 'text-expense',
+      barColor: 'bg-expense',
+      currentAmount: currentMonthSummary.totalExpenses,
+      goalCategory: 'expense' as const,
+    },
+    {
+      label: 'Savings',
+      amount: totalSavings,
+      color: 'text-savings',
+      barColor: 'bg-savings',
+      currentAmount: currentMonthSummary.totalSavings,
+      goalCategory: 'savings' as const,
+    },
   ];
 
   return (
@@ -28,19 +51,47 @@ export const BudgetSummary = ({ summary }: Readonly<BudgetSummaryProps>) => {
 
       {/* 3 stacked metric cards */}
       <div className="grid grid-rows-3 gap-3">
-        {metrics.map((metric) => (
-          <div
-            key={metric.label}
-            className="bg-surface border border-border rounded-xl px-5 py-4 flex justify-between items-center"
-          >
-            <span className="text-[11px] font-semibold uppercase tracking-[0.1em] text-muted">
-              {metric.label}
-            </span>
-            <span className={`text-xl font-semibold num ${metric.color}`}>
-              ${metric.amount.toFixed(2)}
-            </span>
-          </div>
-        ))}
+        {metrics.map((metric) => {
+          const goal = goals.find(g => g.category === metric.goalCategory) ?? null;
+          const pct = goal !== null
+            ? Math.min(100, Math.round((metric.currentAmount / goal.targetAmount) * 100))
+            : 0;
+
+          return (
+            <div
+              key={metric.label}
+              className="bg-surface border border-border rounded-xl px-5 py-4 flex flex-col justify-between"
+            >
+              <div className="flex justify-between items-center">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.1em] text-muted">
+                  {metric.label}
+                </span>
+                <span className={`text-xl font-semibold num ${metric.color}`}>
+                  ${metric.amount.toFixed(2)}
+                </span>
+              </div>
+              {goal !== null ? (
+                <div className="mt-2">
+                  <div className="flex justify-between items-center mb-1">
+                    <span className="text-[10px] text-muted num">${metric.currentAmount.toFixed(2)}</span>
+                    <span className="text-[10px] text-muted num">${goal.targetAmount.toFixed(2)}</span>
+                  </div>
+                  <div className="w-full h-1.5 bg-border rounded-full overflow-hidden">
+                    <div
+                      role="progressbar"
+                      aria-label={`${metric.label} goal progress`}
+                      aria-valuenow={pct}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      className={`h-full rounded-full ${metric.barColor}`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/GoalModal.tsx
+++ b/src/components/GoalModal.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect, useRef } from "react";
+import { BudgetGoal, BudgetCategory } from "@shared/types/budget";
+
+interface GoalUpdate {
+  category: BudgetCategory;
+  targetAmount: number | null;
+}
+
+interface GoalModalProps {
+  goals: BudgetGoal[];
+  onSave: (updates: GoalUpdate[]) => void;
+  onCancel: () => void;
+}
+
+export const GoalModal = ({ goals, onSave, onCancel }: Readonly<GoalModalProps>) => {
+  const findTarget = (cat: BudgetCategory): string => {
+    const g = goals.find(g => g.category === cat);
+    return g ? g.targetAmount.toString() : '';
+  };
+
+  const [incomeTarget, setIncomeTarget] = useState<string>(() => findTarget('income'));
+  const [expenseLimit, setExpenseLimit] = useState<string>(() => findTarget('expense'));
+  const [savingsGoal, setSavingsGoal] = useState<string>(() => findTarget('savings'));
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const getFocusable = () => Array.from(
+      modal.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled])'
+      )
+    );
+    getFocusable()[0]?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { onCancel(); return; }
+      if (e.key !== 'Tab') return;
+
+      const focusable = getFocusable();
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last?.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
+  const parseTarget = (val: string): number | null => {
+    const n = parseFloat(val);
+    return isNaN(n) || n <= 0 ? null : n;
+  };
+
+  const handleSave = () => {
+    const updates: GoalUpdate[] = [
+      { category: 'income', targetAmount: parseTarget(incomeTarget) },
+      { category: 'expense', targetAmount: parseTarget(expenseLimit) },
+      { category: 'savings', targetAmount: parseTarget(savingsGoal) },
+    ];
+    onSave(updates);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-ink/30"
+        onClick={onCancel}
+        aria-hidden="true"
+      />
+
+      {/* Modal card */}
+      <div
+        ref={modalRef}
+        className="relative bg-surface border border-border rounded-xl p-6 w-full max-w-md mx-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="goal-modal-title"
+      >
+        <h2 id="goal-modal-title" aria-label="Set monthly goals" className="text-base font-semibold text-ink mb-6">
+          Set Monthly Goals
+        </h2>
+
+        {/* Income target */}
+        <div className="mb-5">
+          <label htmlFor="goal-income" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+            Income target
+          </label>
+          <div className="relative">
+            <span className="absolute inset-y-0 left-3 flex items-center text-muted pointer-events-none">$</span>
+            <input
+              id="goal-income"
+              type="number"
+              value={incomeTarget}
+              onChange={(e) => setIncomeTarget(e.target.value)}
+              placeholder="0.00"
+              step="0.01"
+              min="0.01"
+              className="w-full min-h-[44px] pl-8 pr-4 py-2.5 border border-border rounded-lg text-ink bg-transparent placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-ink num"
+            />
+          </div>
+        </div>
+
+        {/* Expense limit */}
+        <div className="mb-5">
+          <label htmlFor="goal-expense" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+            Expense limit
+          </label>
+          <div className="relative">
+            <span className="absolute inset-y-0 left-3 flex items-center text-muted pointer-events-none">$</span>
+            <input
+              id="goal-expense"
+              type="number"
+              value={expenseLimit}
+              onChange={(e) => setExpenseLimit(e.target.value)}
+              placeholder="0.00"
+              step="0.01"
+              min="0.01"
+              className="w-full min-h-[44px] pl-8 pr-4 py-2.5 border border-border rounded-lg text-ink bg-transparent placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-ink num"
+            />
+          </div>
+        </div>
+
+        {/* Savings goal */}
+        <div className="mb-6">
+          <label htmlFor="goal-savings" className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-muted mb-2">
+            Savings goal
+          </label>
+          <div className="relative">
+            <span className="absolute inset-y-0 left-3 flex items-center text-muted pointer-events-none">$</span>
+            <input
+              id="goal-savings"
+              type="number"
+              value={savingsGoal}
+              onChange={(e) => setSavingsGoal(e.target.value)}
+              placeholder="0.00"
+              step="0.01"
+              min="0.01"
+              className="w-full min-h-[44px] pl-8 pr-4 py-2.5 border border-border rounded-lg text-ink bg-transparent placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-ink num"
+            />
+          </div>
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 min-h-[44px] border border-border text-muted rounded-lg font-medium hover:border-ink hover:text-ink cursor-pointer transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink focus-visible:ring-offset-1"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            className="flex-1 min-h-[44px] bg-ink text-surface rounded-lg font-medium hover:opacity-90 cursor-pointer transition-opacity duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink focus-visible:ring-offset-1"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useGoals.ts
+++ b/src/hooks/useGoals.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+import type { BudgetGoal, BudgetCategory } from '@shared/types/budget';
+import { fetchGoals, upsertGoal, deleteGoal } from '../services/goalService';
+
+export function useGoals() {
+  const [goals, setGoals] = useState<BudgetGoal[]>([]);
+  const [goalsLoading, setGoalsLoading] = useState(true);
+
+  useEffect(() => {
+    fetchGoals()
+      .then(data => setGoals(data))
+      .catch(() => setGoals([]))
+      .finally(() => setGoalsLoading(false));
+  }, []);
+
+  const handleSetGoal = async (category: BudgetCategory, targetAmount: number): Promise<void> => {
+    const saved = await upsertGoal(category, targetAmount);
+    setGoals(curr => {
+      const others = curr.filter(g => g.category !== category);
+      return [...others, saved];
+    });
+  };
+
+  const handleDeleteGoal = async (id: string): Promise<void> => {
+    await deleteGoal(id);
+    setGoals(curr => curr.filter(g => g.id !== id));
+  };
+
+  return { goals, goalsLoading, handleSetGoal, handleDeleteGoal };
+}

--- a/src/lib/migrations/002_budget_goals.sql
+++ b/src/lib/migrations/002_budget_goals.sql
@@ -1,0 +1,16 @@
+create table budget_goals (
+  id             uuid primary key default gen_random_uuid(),
+  user_id        uuid not null references auth.users(id) on delete cascade,
+  category       text not null check (category in ('income', 'expense', 'savings')),
+  target_amount  numeric(12,2) not null check (target_amount > 0),
+  created_at     timestamptz default now(),
+  unique(user_id, category)
+);
+
+alter table budget_goals enable row level security;
+
+create policy "Users can manage their own goals"
+  on budget_goals for all
+  using (auth.uid() = user_id);
+
+create index on budget_goals(user_id);

--- a/src/services/goalService.ts
+++ b/src/services/goalService.ts
@@ -1,0 +1,45 @@
+import { supabase } from '../lib/supabase';
+import type { BudgetGoal, BudgetCategory } from '@shared/types/budget';
+
+export async function fetchGoals(): Promise<BudgetGoal[]> {
+  const { data, error } = await supabase
+    .from('budget_goals')
+    .select('*')
+    .order('created_at', { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map(row => ({
+    id: row.id as string,
+    category: row.category as BudgetCategory,
+    targetAmount: row.target_amount as number,
+  }));
+}
+
+export async function upsertGoal(
+  category: BudgetCategory,
+  targetAmount: number,
+): Promise<BudgetGoal> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+  const { data, error } = await supabase
+    .from('budget_goals')
+    .upsert(
+      { user_id: user.id, category, target_amount: targetAmount },
+      { onConflict: 'user_id,category' },
+    )
+    .select()
+    .single();
+  if (error) throw error;
+  return {
+    id: data.id as string,
+    category: data.category as BudgetCategory,
+    targetAmount: data.target_amount as number,
+  };
+}
+
+export async function deleteGoal(id: string): Promise<void> {
+  const { error } = await supabase
+    .from('budget_goals')
+    .delete()
+    .eq('id', id);
+  if (error) throw error;
+}

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, devices } from '@playwright/test';
+
+test.use({ ...devices['Pixel 5'] });
+
+test.describe('@mobile Mobile viewport tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock Supabase auth to return no session
+    await page.route('**/auth/v1/**', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { session: null }, error: null }),
+      });
+    });
+  });
+
+  test('Login page renders all key elements at mobile viewport', async ({ page }) => {
+    await page.goto('http://localhost:4173');
+    // Check for VistaFi heading or login elements
+    await expect(page.getByRole('heading', { name: /vistafi/i })).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+  });
+
+  test('Login input fields are accessible at mobile viewport', async ({ page }) => {
+    await page.goto('http://localhost:4173');
+    const emailInput = page.getByLabel(/email/i);
+    const passwordInput = page.getByLabel(/password/i);
+    await expect(emailInput).toBeVisible();
+    await expect(passwordInput).toBeVisible();
+  });
+
+  test('No horizontal scroll overflow on login page at 375px', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('http://localhost:4173');
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const innerWidth = await page.evaluate(() => window.innerWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(innerWidth + 1);
+  });
+
+  test('Signup page renders correctly at mobile viewport', async ({ page }) => {
+    await page.goto('http://localhost:4173');
+    // Navigate to signup if there's a link
+    const signupLink = page.getByRole('link', { name: /sign up|create account/i });
+    if (await signupLink.isVisible()) {
+      await signupLink.click();
+      await expect(page.getByRole('heading', { name: /sign up|create account/i })).toBeVisible();
+    } else {
+      // Just verify no horizontal overflow
+      const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+      const innerWidth = await page.evaluate(() => window.innerWidth);
+      expect(scrollWidth).toBeLessThanOrEqual(innerWidth + 1);
+    }
+  });
+});

--- a/tests/unit/budgetUtils.test.ts
+++ b/tests/unit/budgetUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calculateBudgetSummary, generateId } from '@shared/utils/budgetUtils'
+import { calculateBudgetSummary, calculateCurrentMonthSummary, generateId } from '@shared/utils/budgetUtils'
 import { BudgetItem } from '@shared/types/budget'
 
 const makeItem = (overrides: Partial<BudgetItem> & Pick<BudgetItem, 'category' | 'amount'>): BudgetItem =>
@@ -107,6 +107,54 @@ describe('calculateBudgetSummary', () => {
     ]
     const { balance } = calculateBudgetSummary(items)
     expect(balance).toBeCloseTo(66.66, 2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// calculateCurrentMonthSummary
+// ---------------------------------------------------------------------------
+
+describe('calculateCurrentMonthSummary', () => {
+  it('returns zeros when all items are in a different month', () => {
+    // Given — items all from 2023-11, filtering for 2024-01
+    const items: BudgetItem[] = [
+      { id: '1', description: 'Salary', amount: 4000, category: 'income', date: '2023-11-01' },
+      { id: '2', description: 'Rent', amount: 1500, category: 'expense', date: '2023-11-05' },
+    ]
+    // When
+    const result = calculateCurrentMonthSummary(items, '2024-01')
+    // Then
+    expect(result).toEqual({ totalIncome: 0, totalExpenses: 0, totalSavings: 0, balance: 0 })
+  })
+
+  it('sums only items matching the given month string', () => {
+    // Given — mixed months
+    const items: BudgetItem[] = [
+      { id: '1', description: 'Salary', amount: 4000, category: 'income', date: '2024-01-01' },
+      { id: '2', description: 'Bonus', amount: 500, category: 'income', date: '2024-02-15' },
+      { id: '3', description: 'Rent', amount: 1500, category: 'expense', date: '2024-01-05' },
+    ]
+    // When
+    const result = calculateCurrentMonthSummary(items, '2024-01')
+    // Then
+    expect(result).toEqual({
+      totalIncome: 4000,
+      totalExpenses: 1500,
+      totalSavings: 0,
+      balance: 2500,
+    })
+  })
+
+  it('uses current month by default when no month arg is provided', () => {
+    // Given — item dated in current month
+    const currentMonth = new Date().toISOString().slice(0, 7)
+    const items: BudgetItem[] = [
+      { id: '1', description: 'Salary', amount: 3000, category: 'income', date: `${currentMonth}-01` },
+    ]
+    // When — no month arg, defaults to current month
+    const result = calculateCurrentMonthSummary(items)
+    // Then
+    expect(result.totalIncome).toBe(3000)
   })
 })
 

--- a/tests/unit/components/budgetSummary.test.tsx
+++ b/tests/unit/components/budgetSummary.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { BudgetSummary } from '../../../src/components/BudgetSummary'
-import { BudgetSummary as BudgetSummaryType } from '@shared/types/budget'
+import { BudgetSummary as BudgetSummaryType, BudgetGoal } from '@shared/types/budget'
 
 const makeSummary = (overrides: Partial<BudgetSummaryType> = {}): BudgetSummaryType => ({
   totalIncome: 0,
@@ -12,12 +12,15 @@ const makeSummary = (overrides: Partial<BudgetSummaryType> = {}): BudgetSummaryT
   ...overrides,
 })
 
+const noGoals: BudgetGoal[] = []
+const zeroMonthSummary: BudgetSummaryType = makeSummary()
+
 describe('BudgetSummary', () => {
   it('should render income total when given summary data', () => {
     // Given
     const summary = makeSummary({ totalIncome: 5200 })
     // When
-    render(<BudgetSummary summary={summary} />)
+    render(<BudgetSummary summary={summary} goals={noGoals} currentMonthSummary={zeroMonthSummary} />)
     // Then
     expect(screen.getByText('$5200.00')).toBeInTheDocument()
   })
@@ -26,7 +29,7 @@ describe('BudgetSummary', () => {
     // Given
     const summary = makeSummary({ totalExpenses: 2100 })
     // When
-    render(<BudgetSummary summary={summary} />)
+    render(<BudgetSummary summary={summary} goals={noGoals} currentMonthSummary={zeroMonthSummary} />)
     // Then
     expect(screen.getByText('$2100.00')).toBeInTheDocument()
   })
@@ -35,7 +38,7 @@ describe('BudgetSummary', () => {
     // Given
     const summary = makeSummary({ totalSavings: 800 })
     // When
-    render(<BudgetSummary summary={summary} />)
+    render(<BudgetSummary summary={summary} goals={noGoals} currentMonthSummary={zeroMonthSummary} />)
     // Then
     expect(screen.getByText('$800.00')).toBeInTheDocument()
   })
@@ -44,7 +47,7 @@ describe('BudgetSummary', () => {
     // Given
     const summary = makeSummary({ balance: 2300 })
     // When
-    render(<BudgetSummary summary={summary} />)
+    render(<BudgetSummary summary={summary} goals={noGoals} currentMonthSummary={zeroMonthSummary} />)
     // Then
     expect(screen.getByText('$2300.00')).toBeInTheDocument()
   })
@@ -53,7 +56,7 @@ describe('BudgetSummary', () => {
     // Given
     const summary = makeSummary({ balance: 500 })
     // When
-    render(<BudgetSummary summary={summary} />)
+    render(<BudgetSummary summary={summary} goals={noGoals} currentMonthSummary={zeroMonthSummary} />)
     // Then
     const balanceEl = screen.getByText('$500.00')
     expect(balanceEl).toHaveClass('text-income')
@@ -63,9 +66,53 @@ describe('BudgetSummary', () => {
     // Given
     const summary = makeSummary({ balance: -200 })
     // When
-    render(<BudgetSummary summary={summary} />)
+    render(<BudgetSummary summary={summary} goals={noGoals} currentMonthSummary={zeroMonthSummary} />)
     // Then
     const balanceEl = screen.getByText('$-200.00')
     expect(balanceEl).toHaveClass('text-expense')
+  })
+
+  it('renders a progress bar for a category that has a goal', () => {
+    // Given
+    const summary = makeSummary({ totalIncome: 5200 })
+    const goals: BudgetGoal[] = [{ id: 'g1', category: 'income', targetAmount: 6000 }]
+    const currentMonthSummary = makeSummary({ totalIncome: 3000 })
+    // When
+    render(<BudgetSummary summary={summary} goals={goals} currentMonthSummary={currentMonthSummary} />)
+    // Then
+    expect(screen.getByRole('progressbar', { name: /income goal progress/i })).toBeInTheDocument()
+  })
+
+  it('does not render a progress bar when no goal exists for that category', () => {
+    // Given
+    const summary = makeSummary({ totalExpenses: 2100 })
+    const goals: BudgetGoal[] = [] // no expense goal
+    // When
+    render(<BudgetSummary summary={summary} goals={goals} currentMonthSummary={zeroMonthSummary} />)
+    // Then
+    expect(screen.queryByRole('progressbar', { name: /expense goal progress/i })).not.toBeInTheDocument()
+  })
+
+  it('progress bar has correct aria-label', () => {
+    // Given
+    const summary = makeSummary({ totalSavings: 800 })
+    const goals: BudgetGoal[] = [{ id: 'g2', category: 'savings', targetAmount: 1000 }]
+    const currentMonthSummary = makeSummary({ totalSavings: 500 })
+    // When
+    render(<BudgetSummary summary={summary} goals={goals} currentMonthSummary={currentMonthSummary} />)
+    // Then
+    expect(screen.getByRole('progressbar', { name: 'Savings goal progress' })).toBeInTheDocument()
+  })
+
+  it('shows current month amount and target amount as text in the progress section', () => {
+    // Given
+    const summary = makeSummary({ totalExpenses: 2100 })
+    const goals: BudgetGoal[] = [{ id: 'g3', category: 'expense', targetAmount: 2500 }]
+    const currentMonthSummary = makeSummary({ totalExpenses: 1800 })
+    // When
+    render(<BudgetSummary summary={summary} goals={goals} currentMonthSummary={currentMonthSummary} />)
+    // Then — both amounts appear as text in the progress section
+    expect(screen.getByText('$1800.00')).toBeInTheDocument()
+    expect(screen.getByText('$2500.00')).toBeInTheDocument()
   })
 })

--- a/tests/unit/components/goalModal.test.tsx
+++ b/tests/unit/components/goalModal.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { GoalModal } from '../../../src/components/GoalModal'
+import { BudgetGoal } from '@shared/types/budget'
+
+describe('GoalModal', () => {
+  it('renders 3 labeled inputs: Income target, Expense limit, Savings goal', () => {
+    // Given / When
+    render(<GoalModal goals={[]} onSave={vi.fn()} onCancel={vi.fn()} />)
+    // Then
+    expect(screen.getByLabelText(/income target/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/expense limit/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/savings goal/i)).toBeInTheDocument()
+  })
+
+  it('pre-fills each input with existing goal targetAmount', () => {
+    // Given
+    const goals: BudgetGoal[] = [
+      { id: 'g1', category: 'income', targetAmount: 5000 },
+      { id: 'g2', category: 'expense', targetAmount: 2500 },
+      { id: 'g3', category: 'savings', targetAmount: 1000 },
+    ]
+    // When
+    render(<GoalModal goals={goals} onSave={vi.fn()} onCancel={vi.fn()} />)
+    // Then
+    expect(screen.getByLabelText(/income target/i)).toHaveValue(5000)
+    expect(screen.getByLabelText(/expense limit/i)).toHaveValue(2500)
+    expect(screen.getByLabelText(/savings goal/i)).toHaveValue(1000)
+  })
+
+  it('clicking Save calls onSave with correct updates array', async () => {
+    // Given
+    const user = userEvent.setup()
+    const goals: BudgetGoal[] = [
+      { id: 'g1', category: 'income', targetAmount: 5000 },
+    ]
+    const onSave = vi.fn()
+    render(<GoalModal goals={goals} onSave={onSave} onCancel={vi.fn()} />)
+
+    // When — change income target and save
+    const incomeInput = screen.getByLabelText(/income target/i)
+    await user.clear(incomeInput)
+    await user.type(incomeInput, '6000')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    // Then
+    expect(onSave).toHaveBeenCalledTimes(1)
+    const callArg = onSave.mock.calls[0][0] as Array<{ category: string; targetAmount: number | null }>
+    const incomeUpdate = callArg.find(u => u.category === 'income')
+    expect(incomeUpdate?.targetAmount).toBe(6000)
+  })
+
+  it('leaving an input empty means that category targetAmount is null in onSave payload', async () => {
+    // Given
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(<GoalModal goals={[]} onSave={onSave} onCancel={vi.fn()} />)
+
+    // When — leave all inputs empty and save
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    // Then
+    const callArg = onSave.mock.calls[0][0] as Array<{ category: string; targetAmount: number | null }>
+    expect(callArg.every(u => u.targetAmount === null)).toBe(true)
+  })
+
+  it('clicking Cancel calls onCancel without calling onSave', async () => {
+    // Given
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    const onCancel = vi.fn()
+    render(<GoalModal goals={[]} onSave={onSave} onCancel={onCancel} />)
+
+    // When
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    // Then
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSave).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/services/goalService.test.ts
+++ b/tests/unit/services/goalService.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchGoals, upsertGoal, deleteGoal } from '../../../src/services/goalService';
+import { supabase } from '../../../src/lib/supabase';
+
+vi.mock('../../../src/lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(),
+    },
+  },
+}));
+
+const mockUser = { id: 'user-123', email: 'test@test.com' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- fetchGoals ---
+
+describe('fetchGoals', () => {
+  it('returns empty array when Supabase returns null data', async () => {
+    vi.mocked(supabase.from).mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({ data: null, error: null }),
+      }),
+    } as ReturnType<typeof supabase.from>);
+
+    const result = await fetchGoals();
+    expect(result).toEqual([]);
+  });
+
+  it('maps target_amount snake_case to targetAmount camelCase', async () => {
+    const rawRows = [
+      { id: 'goal-1', category: 'income', target_amount: 5000 },
+      { id: 'goal-2', category: 'expense', target_amount: 2000 },
+    ];
+    vi.mocked(supabase.from).mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({ data: rawRows, error: null }),
+      }),
+    } as ReturnType<typeof supabase.from>);
+
+    const result = await fetchGoals();
+    expect(result).toEqual([
+      { id: 'goal-1', category: 'income', targetAmount: 5000 },
+      { id: 'goal-2', category: 'expense', targetAmount: 2000 },
+    ]);
+  });
+});
+
+// --- upsertGoal ---
+
+describe('upsertGoal', () => {
+  it('calls supabase.upsert with correct payload', async () => {
+    vi.mocked(supabase.auth.getUser).mockResolvedValue({
+      data: { user: mockUser as never },
+      error: null,
+    });
+    const mockUpsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { id: 'goal-1', category: 'income', target_amount: 5000 },
+          error: null,
+        }),
+      }),
+    });
+    vi.mocked(supabase.from).mockReturnValue({
+      upsert: mockUpsert,
+    } as ReturnType<typeof supabase.from>);
+
+    const result = await upsertGoal('income', 5000);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      { user_id: 'user-123', category: 'income', target_amount: 5000 },
+      { onConflict: 'user_id,category' },
+    );
+    expect(result).toEqual({ id: 'goal-1', category: 'income', targetAmount: 5000 });
+  });
+
+  it('throws if user is not authenticated', async () => {
+    vi.mocked(supabase.auth.getUser).mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    await expect(upsertGoal('income', 5000)).rejects.toThrow('Not authenticated');
+  });
+});
+
+// --- deleteGoal ---
+
+describe('deleteGoal', () => {
+  it('calls supabase.delete with correct id filter', async () => {
+    const mockEq = vi.fn().mockResolvedValue({ error: null });
+    const mockDelete = vi.fn().mockReturnValue({ eq: mockEq });
+    vi.mocked(supabase.from).mockReturnValue({
+      delete: mockDelete,
+    } as ReturnType<typeof supabase.from>);
+
+    await expect(deleteGoal('goal-1')).resolves.toBeUndefined();
+    expect(supabase.from).toHaveBeenCalledWith('budget_goals');
+    expect(mockEq).toHaveBeenCalledWith('id', 'goal-1');
+  });
+});


### PR DESCRIPTION
- Add BudgetGoal type and calculateCurrentMonthSummary util
- Add goalService (fetchGoals/upsertGoal/deleteGoal) with Supabase upsert on user_id,category conflict
- Update BudgetSummary to accept goals + currentMonthSummary props; render role=progressbar per category
- Add GoalModal (3 number inputs, empty = null targetAmount, ESC/backdrop dismiss)
- Add useGoals hook with functional setState; Goals button in App header
- Add Supabase migration 002_budget_goals.sql with RLS policy
- Add mobile viewport E2E (Pixel 5, 4 tests) + mobile-chrome Playwright project
- 121 unit/integration tests pass; lint clean; build clean