### PR TITLE
chore: add mobile-release workflow — 

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,0 +1,113 @@
+name: Mobile Release — APK Build & Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+# Lock down all permissions at workflow level.
+# Each job below grants only the minimum it needs.
+permissions: {}
+
+jobs:
+  # ── Gate ─────────────────────────────────────────────────────────────────
+  # Run type-check and unit tests before spending EAS build minutes.
+  test:
+    name: Mobile · Type-Check · Unit Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: mobile
+    env:
+      # Needed locally so supabase.ts can call createClient() at module load.
+      # These are the public anon key + URL — NOT the service_role key.
+      EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
+      EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.EXPO_PUBLIC_SUPABASE_ANON_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mobile/package-lock.json
+      - run: npm ci --legacy-peer-deps
+      - name: Type Check
+        run: npm run type-check
+      - name: Unit Tests
+        run: npm run test:ci
+
+  # ── Build & Release ───────────────────────────────────────────────────────
+  # Trigger an EAS preview build, download the APK, publish a GitHub Release.
+  build-and-release:
+    name: EAS Build · Preview APK · GitHub Release
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Required only for creating GitHub Releases
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mobile/package-lock.json
+      - run: npm ci --legacy-peer-deps
+
+      - name: Install EAS CLI
+        # Install globally so `eas` is on PATH for subsequent steps.
+        run: npm install -g eas-cli
+
+      - name: Build Preview APK via EAS
+        id: eas_build
+        # Supabase env vars are NOT passed here.
+        # EAS fetches them from its own "preview" environment
+        # (configured via `eas env:create` and linked in eas.json).
+        timeout-minutes: 45
+        run: |
+          BUILD_JSON=$(eas build \
+            --profile preview \
+            --platform android \
+            --non-interactive \
+            --json \
+            --wait)
+
+          APK_URL=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.applicationArchiveUrl')
+
+          if [ -z "$APK_URL" ] || [ "$APK_URL" = "null" ]; then
+            echo "::error::APK download URL not found in EAS build output."
+            echo "Full EAS output:"
+            echo "$BUILD_JSON" | jq .
+            exit 1
+          fi
+
+          echo "apk_url=$APK_URL" >> "$GITHUB_OUTPUT"
+        env:
+          EXPO_TOKEN: ${{ secrets.EAS_TOKEN }}
+
+      - name: Download APK from EAS
+        run: curl -fsSL -o vistafi-preview.apk "${{ steps.eas_build.outputs.apk_url }}"
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          # working-directory default applies to `run` steps only.
+          # This action runs from workspace root, so path includes mobile/.
+          files: mobile/vistafi-preview.apk
+          name: "VistaFi ${{ github.ref_name }}"
+          body: |
+            ## Android Preview Build — ${{ github.ref_name }}
+
+            Internal APK built via EAS (preview profile, `distribution: internal`).
+
+            **Install on Android:**
+            1. Enable *Install from unknown sources* in your device settings
+            2. Download `vistafi-preview.apk` below
+            3. Open the file and tap Install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/active-context.md
+++ b/docs/active-context.md
@@ -1,13 +1,15 @@
-# Active Context — chore/apk-build: APK Build via EAS Build
+# Active Context — chore/apk-github-release: APK Auto-Release to GitHub
 
 ## Context
 
-The VistaFi mobile app (Expo SDK 54, React Native 0.81.5) needs a distributable Android APK
-for sideloading / device testing. EAS Build is already configured — `mobile/eas.json` has a
-`preview` profile with `"buildType": "apk"` and `app.json` already has a registered EAS
-projectId. Two code changes are needed before triggering the build.
+The VistaFi mobile app builds a preview APK via EAS, but the artifact only lives on expo.dev.
+This task adds a `mobile-release.yml` GitHub Actions workflow that:
+1. Gates on type-check + unit tests passing
+2. Triggers an EAS preview APK build
+3. Downloads the APK from EAS
+4. Creates a GitHub Release and attaches the APK
 
-Branch: `chore/apk-build`
+Branch: `chore/apk-github-release`
 
 ---
 
@@ -16,61 +18,51 @@ Branch: `chore/apk-build`
 | # | Task | Status |
 |---|------|--------|
 | 1 | Update `docs/active-context.md` | ✅ |
-| 2 | Add signing artifact patterns to `.gitignore` | ✅ |
-| 3 | Add `android.package` to `mobile/app.json` | ✅ |
-| 4 | Security checklist (pre-push) | ✅ |
-| 5 | Commit + push | ✅ |
+| 2 | Create `.github/workflows/mobile-release.yml` | ✅ |
+| 3 | Security compliance check | ✅ |
+| 4 | Commit + push | ⬜ |
 
 ---
 
 ## Files Changed
 
-- `.gitignore` — added `*.jks`, `*.keystore`, `*.p12`, `*.cer`, `*.mobileprovision`
-- `mobile/app.json` — added `"android": { "package": "com.adrayandaleandrew.vistafi" }`
 - `docs/active-context.md` — this file
+- `.github/workflows/mobile-release.yml` — new workflow: EAS build → GitHub Release
 
 ## Files NOT Changed
 
-- `mobile/eas.json` — `preview` profile already has `"buildType": "apk"`
-- All source `.tsx`/`.ts` — no code changes needed for a build config task
-- `.github/workflows/mobile-ci.yml` — CI-triggered EAS build is a future step (Phase 12c)
+- `.github/workflows/mobile-ci.yml` — unchanged; keeps running on every push/PR
+- `mobile/eas.json` — already configured with `preview` profile + `"environment": "preview"`
+- All source `.tsx`/`.ts` — no code changes needed
 
 ---
 
-## User Actions Required (run manually in terminal)
+## Security Decisions
 
-### A. Install EAS CLI (once globally)
+| Decision | Rationale |
+|----------|-----------|
+| `permissions: {}` at workflow level | Restricts all by default; each job opts in explicitly |
+| `test` job: `contents: read` only | No release creation needed |
+| `build-and-release` job: `contents: write` only | Minimum for GitHub Release creation |
+| Supabase env vars NOT passed to EAS build | EAS fetches them from its own `preview` environment (eas.json `"environment": "preview"`) |
+| Supabase env vars passed only to `test` job | Unit tests need them locally because `supabase.ts` runs `createClient` at module load |
+| `EXPO_TOKEN: ${{ secrets.EAS_TOKEN }}` | Only secret the EAS build step needs; stored in GitHub Secrets |
+| `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` | Built-in; no user setup required |
+| Preview APK, not production | `distribution: internal`; acceptable for GitHub Releases |
+| Error guard on APK URL extraction | Fails fast and loudly if EAS output format changes |
+
+## GitHub Secret Required (user sets once)
+
+- `EAS_TOKEN` — Expo personal access token (expo.dev → Account Settings → Access Tokens)
+
+---
+
+## How to Trigger a Release
+
 ```bash
-npm install -g eas-cli
-eas --version   # must be >= 5.0.0
+# Tag a commit and push — workflow fires automatically
+git tag v1.0.0
+git push origin v1.0.0
 ```
 
-### B. Log in to Expo
-```bash
-eas login
-eas whoami
-```
-
-### C. Set EAS Environment Variables (from `mobile/` directory)
-```bash
-cd mobile
-eas env:create preview --name EXPO_PUBLIC_SUPABASE_URL --value "https://YOUR_PROJECT.supabase.co" --visibility sensitive --scope project
-eas env:create preview --name EXPO_PUBLIC_SUPABASE_ANON_KEY --value "eyJhbGc...YOUR_ANON_KEY" --visibility sensitive --scope project
-eas env:list preview   # verify both appear
-```
-
-### D. Trigger the APK build
-```bash
-cd mobile
-eas build --platform android --profile preview
-# Answer "Yes" to keystore generation on first run
-```
-
-### E. Download the APK
-- expo.dev → Projects → vistafi → Builds → completed build → Download
-- Or: `eas build:list --platform android --limit 3`
-
-### F. Install on Android device
-1. Transfer `.apk` to device
-2. Settings → Security → Install Unknown Apps → enable
-3. Open `.apk` → Install
+Or: GitHub Actions → Mobile Release workflow → Run workflow (manual dispatch).


### PR DESCRIPTION
Adds .github/workflows/mobile-release.yml that:
- Gates on type-check + unit tests before spending EAS build minutes
- Triggers EAS preview APK build (non-interactive, waits for artifact)
- Downloads APK directly from EAS artifact URL
- Creates a GitHub Release with the APK attached

Security: permissions locked to {} at workflow level; test job gets contents:read only; release job gets contents:write only; Supabase env vars are NOT passed to the EAS build step (EAS fetches them from its own preview environment); only EAS_TOKEN + built-in GITHUB_TOKEN are used.