### PR TITLE
fix: add transaction user_id, tab icons, biometrics login

### DIFF
--- a/docs/active-context.md
+++ b/docs/active-context.md
@@ -1,15 +1,13 @@
-# Active Context — chore/apk-github-release: APK Auto-Release to GitHub
+# Active Context — fix/mobile-core-bugs: Mobile Core Bugs
 
 ## Context
 
-The VistaFi mobile app builds a preview APK via EAS, but the artifact only lives on expo.dev.
-This task adds a `mobile-release.yml` GitHub Actions workflow that:
-1. Gates on type-check + unit tests passing
-2. Triggers an EAS preview APK build
-3. Downloads the APK from EAS
-4. Creates a GitHub Release and attaches the APK
+Three bugs found in the installed APK that need fixing:
+1. **Add Transaction silently fails** — `budgetService.ts` inserts without `user_id`; Supabase RLS rejects it
+2. **Bottom nav icons broken** — `_layout.tsx` has no `tabBarIcon` definitions; Expo renders placeholder boxes
+3. **Biometrics toggle non-functional** — `login.tsx` never reads the pref or calls `LocalAuthentication.authenticate()`
 
-Branch: `chore/apk-github-release`
+Branch: `fix/mobile-core-bugs`
 
 ---
 
@@ -18,51 +16,19 @@ Branch: `chore/apk-github-release`
 | # | Task | Status |
 |---|------|--------|
 | 1 | Update `docs/active-context.md` | ✅ |
-| 2 | Create `.github/workflows/mobile-release.yml` | ✅ |
-| 3 | Security compliance check | ✅ |
-| 4 | Commit + push | ⬜ |
+| 2 | Bug 1 — `budgetService.ts` + `useBudgetMutations.ts` | ✅ |
+| 3 | Bug 2 — `(tabs)/_layout.tsx` icons | ✅ |
+| 4 | Bug 3 — `login.tsx` biometrics | ✅ |
+| 5 | Update affected tests | ✅ |
+| 6 | Compliance check + commit + push | ⬜ |
 
 ---
 
 ## Files Changed
 
-- `docs/active-context.md` — this file
-- `.github/workflows/mobile-release.yml` — new workflow: EAS build → GitHub Release
-
-## Files NOT Changed
-
-- `.github/workflows/mobile-ci.yml` — unchanged; keeps running on every push/PR
-- `mobile/eas.json` — already configured with `preview` profile + `"environment": "preview"`
-- All source `.tsx`/`.ts` — no code changes needed
-
----
-
-## Security Decisions
-
-| Decision | Rationale |
-|----------|-----------|
-| `permissions: {}` at workflow level | Restricts all by default; each job opts in explicitly |
-| `test` job: `contents: read` only | No release creation needed |
-| `build-and-release` job: `contents: write` only | Minimum for GitHub Release creation |
-| Supabase env vars NOT passed to EAS build | EAS fetches them from its own `preview` environment (eas.json `"environment": "preview"`) |
-| Supabase env vars passed only to `test` job | Unit tests need them locally because `supabase.ts` runs `createClient` at module load |
-| `EXPO_TOKEN: ${{ secrets.EAS_TOKEN }}` | Only secret the EAS build step needs; stored in GitHub Secrets |
-| `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` | Built-in; no user setup required |
-| Preview APK, not production | `distribution: internal`; acceptable for GitHub Releases |
-| Error guard on APK URL extraction | Fails fast and loudly if EAS output format changes |
-
-## GitHub Secret Required (user sets once)
-
-- `EAS_TOKEN` — Expo personal access token (expo.dev → Account Settings → Access Tokens)
-
----
-
-## How to Trigger a Release
-
-```bash
-# Tag a commit and push — workflow fires automatically
-git tag v1.0.0
-git push origin v1.0.0
-```
-
-Or: GitHub Actions → Mobile Release workflow → Run workflow (manual dispatch).
+- `mobile/src/services/budgetService.ts` — `addItem` now accepts `userId` param, includes it in insert
+- `mobile/src/hooks/useBudgetMutations.ts` — `useAddItem` injects `userId` into `mutationFn`
+- `mobile/app/(tabs)/_layout.tsx` — full replacement with Ionicons tab icons
+- `mobile/app/(auth)/login.tsx` — biometrics flow: reads pref, triggers auth on mount, conditional JSX
+- `mobile/src/hooks/__tests__/useBudgetMutations.test.ts` — Test 1 assertion updated for new signature
+- `mobile/app/(auth)/__tests__/login.test.tsx` — 3 new mocks + 4 new biometric tests

--- a/mobile/app/(auth)/__tests__/login.test.tsx
+++ b/mobile/app/(auth)/__tests__/login.test.tsx
@@ -19,8 +19,9 @@ jest.mock('../../../src/providers/AuthProvider', () => ({
 
 // Mock expo-router
 const mockPush = jest.fn()
+const mockReplace = jest.fn()
 jest.mock('expo-router', () => ({
-  useRouter: () => ({ push: mockPush, replace: jest.fn() }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
 }))
 
 // Mock expo-haptics
@@ -35,24 +36,62 @@ jest.mock('react-native-reanimated', () => {
   return Reanimated
 })
 
+// Mock expo-local-authentication — no hardware by default → showForm=true
+jest.mock('expo-local-authentication', () => ({
+  hasHardwareAsync: jest.fn().mockResolvedValue(false),
+  isEnrolledAsync: jest.fn().mockResolvedValue(false),
+  authenticate: jest.fn(),
+}))
+
+// Mock AsyncStorage — pref off by default → showForm=true
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}))
+
+// Mock supabase
+jest.mock('../../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+    },
+  },
+}))
+
+import * as LocalAuthentication from 'expo-local-authentication'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { supabase } from '../../../src/lib/supabase'
+
+const mockHasHardware = LocalAuthentication.hasHardwareAsync as jest.Mock
+const mockIsEnrolled = LocalAuthentication.isEnrolledAsync as jest.Mock
+const mockAuthenticate = LocalAuthentication.authenticate as jest.Mock
+const mockGetItem = AsyncStorage.getItem as jest.Mock
+const mockGetSession = supabase.auth.getSession as jest.Mock
+
 describe('LoginScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockError.current = null
+    // Default: pref off → showForm=true immediately
+    mockGetItem.mockResolvedValue(null)
+    mockHasHardware.mockResolvedValue(false)
+    mockIsEnrolled.mockResolvedValue(false)
+    mockGetSession.mockResolvedValue({ data: { session: null } })
   })
 
-  test('1. renders email input, password input, and submit Pressable', () => {
+  test('1. renders email input, password input, and submit Pressable', async () => {
     // Given/When
     const { getByTestId } = render(<LoginScreen />)
-    // Then
-    expect(getByTestId('email-input')).toBeTruthy()
+    // Then — wait for useEffect to set showForm=true
+    await waitFor(() => expect(getByTestId('email-input')).toBeTruthy())
     expect(getByTestId('password-input')).toBeTruthy()
     expect(getByTestId('submit-button')).toBeTruthy()
   })
 
-  test('2. submit Pressable has minHeight of 44 (touch target rule)', () => {
+  test('2. submit Pressable has minHeight of 44 (touch target rule)', async () => {
     // Given/When
     const { getByTestId } = render(<LoginScreen />)
+    await waitFor(() => expect(getByTestId('submit-button')).toBeTruthy())
     const btn = getByTestId('submit-button')
     // Then — style prop or StyleSheet must include minHeight: 44
     const style = btn.props.style
@@ -64,6 +103,7 @@ describe('LoginScreen', () => {
     // Given
     mockSignIn.mockResolvedValue(undefined)
     const { getByTestId } = render(<LoginScreen />)
+    await waitFor(() => expect(getByTestId('email-input')).toBeTruthy())
     fireEvent.changeText(getByTestId('email-input'), 'user@example.com')
     fireEvent.changeText(getByTestId('password-input'), 'password123')
     // When
@@ -75,31 +115,77 @@ describe('LoginScreen', () => {
   })
 
   test('4. shows inline error Text when useAuth().error is non-null (ternary)', async () => {
-    // Given — error is set
+    // Given — mockError.current is read by the mock factory on each render
     mockError.current = 'Incorrect email or password.'
-    jest.resetModules()
-    // Re-mock with error
-    jest.doMock('../../../src/providers/AuthProvider', () => ({
-      useAuth: () => ({
-        signIn: mockSignIn,
-        error: 'Incorrect email or password.',
-        isLoading: false,
-        user: null,
-        signUp: jest.fn(),
-        signOut: jest.fn(),
-      }),
-    }))
-    const LoginWithError = require('../login').default
     // When
-    const { getByText } = render(<LoginWithError />)
+    const { getByText } = render(<LoginScreen />)
     // Then
-    expect(getByText('Incorrect email or password.')).toBeTruthy()
+    await waitFor(() => expect(getByText('Incorrect email or password.')).toBeTruthy())
   })
 
-  test('5. Create account Pressable renders', () => {
+  test('5. Create account Pressable renders', async () => {
     // Given/When
     const { getByTestId } = render(<LoginScreen />)
+    await waitFor(() => expect(getByTestId('create-account-button')).toBeTruthy())
+  })
+
+  test('6. biometric prompt shown when pref=true, hardware available, enrolled', async () => {
+    // Given — authenticate never resolves so biometric UI stays visible
+    mockGetItem.mockResolvedValue('true')
+    mockHasHardware.mockResolvedValue(true)
+    mockIsEnrolled.mockResolvedValue(true)
+    mockAuthenticate.mockImplementation(() => new Promise(() => {}))
+    // When
+    const { getByTestId } = render(<LoginScreen />)
     // Then
-    expect(getByTestId('create-account-button')).toBeTruthy()
+    await waitFor(() => expect(getByTestId('biometric-button')).toBeTruthy())
+    expect(getByTestId('use-password-button')).toBeTruthy()
+  })
+
+  test('7. biometric success + valid session → router.replace called', async () => {
+    // Given
+    mockGetItem.mockResolvedValue('true')
+    mockHasHardware.mockResolvedValue(true)
+    mockIsEnrolled.mockResolvedValue(true)
+    mockAuthenticate.mockResolvedValue({ success: true })
+    mockGetSession.mockResolvedValue({ data: { session: { user: { id: 'u1' } } } })
+    // When
+    render(<LoginScreen />)
+    // Then
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/(tabs)'))
+  })
+
+  test('8. biometric failure → form shown (email-input visible)', async () => {
+    // Given — first authenticate call (auto-triggered on mount) pends so UI is visible
+    mockGetItem.mockResolvedValue('true')
+    mockHasHardware.mockResolvedValue(true)
+    mockIsEnrolled.mockResolvedValue(true)
+    // Call #1 (from useEffect) never resolves → biometric UI stays visible
+    // Call #2 (from press) returns failure → showForm=true
+    mockAuthenticate
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce({ success: false })
+    const { getByTestId } = render(<LoginScreen />)
+    await waitFor(() => expect(getByTestId('biometric-button')).toBeTruthy())
+    // When
+    await act(async () => {
+      fireEvent.press(getByTestId('biometric-button'))
+    })
+    // Then
+    await waitFor(() => expect(getByTestId('email-input')).toBeTruthy())
+  })
+
+  test('9. "Use email instead" button → form shown', async () => {
+    // Given — authenticate never resolves so biometric UI stays visible
+    mockGetItem.mockResolvedValue('true')
+    mockHasHardware.mockResolvedValue(true)
+    mockIsEnrolled.mockResolvedValue(true)
+    mockAuthenticate.mockImplementation(() => new Promise(() => {}))
+    const { getByTestId } = render(<LoginScreen />)
+    await waitFor(() => expect(getByTestId('use-password-button')).toBeTruthy())
+    // When
+    fireEvent.press(getByTestId('use-password-button'))
+    // Then
+    await waitFor(() => expect(getByTestId('email-input')).toBeTruthy())
   })
 })

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   View,
   Text,
@@ -13,15 +13,22 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated'
 import * as Haptics from 'expo-haptics'
+import * as LocalAuthentication from 'expo-local-authentication'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useRouter } from 'expo-router'
 import { useAuth } from '../../src/providers/AuthProvider'
+import { supabase } from '../../src/lib/supabase'
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable)
+
+const BIOMETRICS_PREF_KEY = 'vistafi-biometrics-enabled'
 
 export default function LoginScreen() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [validationError, setValidationError] = useState<string | null>(null)
+  const [biometricAvailable, setBiometricAvailable] = useState(false)
+  const [showForm, setShowForm] = useState(false)
   const { signIn, error: authError } = useAuth()
   const router = useRouter()
   const scale = useSharedValue(1)
@@ -29,6 +36,39 @@ export default function LoginScreen() {
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: scale.value }],
   }))
+
+  const triggerBiometric = async () => {
+    const result = await LocalAuthentication.authenticate({
+      promptMessage: 'Sign in to VistaFi',
+    })
+    if (result.success) {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (session !== null) {
+        router.replace('/(tabs)')
+        return
+      }
+    }
+    setShowForm(true)
+  }
+
+  useEffect(() => {
+    async function checkBiometrics() {
+      const pref = await AsyncStorage.getItem(BIOMETRICS_PREF_KEY)
+      if (pref !== 'true') {
+        setShowForm(true)
+        return
+      }
+      const hasHardware = await LocalAuthentication.hasHardwareAsync()
+      const isEnrolled = await LocalAuthentication.isEnrolledAsync()
+      if (!hasHardware || !isEnrolled) {
+        setShowForm(true)
+        return
+      }
+      setBiometricAvailable(true)
+      triggerBiometric()
+    }
+    checkBiometrics()
+  }, [])
 
   const handleSubmit = async () => {
     setValidationError(null)
@@ -53,51 +93,78 @@ export default function LoginScreen() {
         <Text style={styles.title}>VistaFi</Text>
         <Text style={styles.subtitle}>Sign in to your account</Text>
 
-        <TextInput
-          testID="email-input"
-          style={styles.input}
-          value={email}
-          onChangeText={setEmail}
-          placeholder="Email"
-          placeholderTextColor="#857F72"
-          keyboardType="email-address"
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
+        {showForm ? (
+          <View>
+            <TextInput
+              testID="email-input"
+              style={styles.input}
+              value={email}
+              onChangeText={setEmail}
+              placeholder="Email"
+              placeholderTextColor="#857F72"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
 
-        <TextInput
-          testID="password-input"
-          style={styles.input}
-          value={password}
-          onChangeText={setPassword}
-          placeholder="Password"
-          placeholderTextColor="#857F72"
-          secureTextEntry
-        />
+            <TextInput
+              testID="password-input"
+              style={styles.input}
+              value={password}
+              onChangeText={setPassword}
+              placeholder="Password"
+              placeholderTextColor="#857F72"
+              secureTextEntry
+            />
 
-        {displayError ? <Text style={styles.error}>{displayError}</Text> : null}
+            {displayError ? <Text style={styles.error}>{displayError}</Text> : null}
 
-        <AnimatedPressable
-          testID="submit-button"
-          style={[styles.submitButton, animatedStyle]}
-          onPressIn={() => { scale.value = withSpring(0.95) }}
-          onPressOut={() => { scale.value = withSpring(1) }}
-          onPress={handleSubmit}
-          accessibilityRole="button"
-          accessibilityLabel="Sign in"
-        >
-          <Text style={styles.submitText}>Sign In</Text>
-        </AnimatedPressable>
+            <AnimatedPressable
+              testID="submit-button"
+              style={[styles.submitButton, animatedStyle]}
+              onPressIn={() => { scale.value = withSpring(0.95) }}
+              onPressOut={() => { scale.value = withSpring(1) }}
+              onPress={handleSubmit}
+              accessibilityRole="button"
+              accessibilityLabel="Sign in"
+            >
+              <Text style={styles.submitText}>Sign In</Text>
+            </AnimatedPressable>
 
-        <Pressable
-          testID="create-account-button"
-          style={styles.linkButton}
-          onPress={() => router.push('/(auth)/signup')}
-          accessibilityRole="button"
-          accessibilityLabel="Create account"
-        >
-          <Text style={styles.linkText}>Create account</Text>
-        </Pressable>
+            <Pressable
+              testID="create-account-button"
+              style={styles.linkButton}
+              onPress={() => router.push('/(auth)/signup')}
+              accessibilityRole="button"
+              accessibilityLabel="Create account"
+            >
+              <Text style={styles.linkText}>Create account</Text>
+            </Pressable>
+          </View>
+        ) : (
+          biometricAvailable ? (
+            <View style={styles.biometricContainer}>
+              <Pressable
+                testID="biometric-button"
+                style={styles.biometricButton}
+                onPress={triggerBiometric}
+                accessibilityRole="button"
+                accessibilityLabel="Sign in with biometrics"
+              >
+                <Text style={styles.submitText}>Use Biometrics</Text>
+              </Pressable>
+              <Pressable
+                testID="use-password-button"
+                style={styles.linkButton}
+                onPress={() => setShowForm(true)}
+                accessibilityRole="button"
+                accessibilityLabel="Use email and password instead"
+              >
+                <Text style={styles.linkText}>Use email instead</Text>
+              </Pressable>
+            </View>
+          ) : null
+        )}
       </View>
     </SafeAreaView>
   )
@@ -165,5 +232,18 @@ const styles = StyleSheet.create({
   linkText: {
     color: '#857F72',
     fontSize: 14,
+  },
+  biometricContainer: {
+    alignItems: 'center',
+    gap: 16,
+  },
+  biometricButton: {
+    backgroundColor: '#18170F',
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+    width: '100%',
+    paddingVertical: 14,
   },
 })

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,12 +1,66 @@
 import { Tabs } from 'expo-router'
+import { StyleSheet } from 'react-native'
+import Ionicons from '@expo/vector-icons/Ionicons'
+
+type IoniconName = React.ComponentProps<typeof Ionicons>['name']
+
+const ICON_SIZE = 24
+
+function renderTabIcon(focused: boolean, active: IoniconName, inactive: IoniconName) {
+  return (
+    <Ionicons
+      name={focused ? active : inactive}
+      size={ICON_SIZE}
+      color={focused ? '#18170F' : '#857F72'}
+    />
+  )
+}
 
 export default function TabLayout() {
   return (
-    <Tabs screenOptions={{ headerShown: false }}>
-      <Tabs.Screen name="index" options={{ title: 'Home' }} />
-      <Tabs.Screen name="add" options={{ title: 'Add' }} />
-      <Tabs.Screen name="history" options={{ title: 'History' }} />
-      <Tabs.Screen name="profile" options={{ title: 'Profile' }} />
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: '#18170F',
+        tabBarInactiveTintColor: '#857F72',
+        tabBarStyle: styles.tabBar,
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ focused }) => renderTabIcon(focused, 'home', 'home-outline'),
+        }}
+      />
+      <Tabs.Screen
+        name="add"
+        options={{
+          title: 'Add',
+          tabBarIcon: ({ focused }) => renderTabIcon(focused, 'add-circle', 'add-circle-outline'),
+        }}
+      />
+      <Tabs.Screen
+        name="history"
+        options={{
+          title: 'History',
+          tabBarIcon: ({ focused }) => renderTabIcon(focused, 'list', 'list-outline'),
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: 'Profile',
+          tabBarIcon: ({ focused }) => renderTabIcon(focused, 'person', 'person-outline'),
+        }}
+      />
     </Tabs>
   )
 }
+
+const styles = StyleSheet.create({
+  tabBar: {
+    backgroundColor: '#FDFCFA',
+    borderTopColor: '#E0DBCF',
+  },
+})

--- a/mobile/src/hooks/__tests__/useBudgetMutations.test.ts
+++ b/mobile/src/hooks/__tests__/useBudgetMutations.test.ts
@@ -46,7 +46,7 @@ describe('useAddItem', () => {
     // When
     act(() => { result.current.mutate(newItemInput) })
     // Then
-    await waitFor(() => expect(mockAddItem).toHaveBeenCalledWith(newItemInput))
+    await waitFor(() => expect(mockAddItem).toHaveBeenCalledWith('user-123', newItemInput))
   })
 
   test('2. optimistic update: cache updated before server confirms', async () => {

--- a/mobile/src/hooks/useBudgetMutations.ts
+++ b/mobile/src/hooks/useBudgetMutations.ts
@@ -31,7 +31,7 @@ export function useAddItem(userId: string) {
   }, [queryClient, queryKey])
 
   return useMutation({
-    mutationFn: addItem,
+    mutationFn: (newItem: Omit<BudgetItem, 'id'>) => addItem(userId, newItem),
     onMutate,
     onError,
     onSettled,

--- a/mobile/src/services/budgetService.ts
+++ b/mobile/src/services/budgetService.ts
@@ -12,16 +12,17 @@ export async function fetchItems(): Promise<BudgetItem[]> {
 }
 
 export async function addItem(
+  userId: string,
   item: Omit<BudgetItem, 'id'>
 ): Promise<BudgetItem> {
   const { data, error } = await supabase
     .from('budget_items')
-    .insert(item)
+    .insert({ ...item, user_id: userId })
     .select()
     .single()
 
   if (error) throw error
-  return data
+  return data as BudgetItem
 }
 
 export async function updateItem(item: BudgetItem): Promise<BudgetItem> {


### PR DESCRIPTION
- budgetService.addItem now accepts userId and includes it in the Supabase insert so RLS does not reject the row
- useAddItem wraps mutationFn to inject userId automatically
- (tabs)/_layout.tsx replaced with Ionicons tab icons (home/add-circle/list/person, filled when active)
- login.tsx reads biometrics pref from AsyncStorage on mount, triggers LocalAuthentication.authenticate(), falls back to email form on failure or missing session
- Tests: useBudgetMutations test 1 assertion updated; 4 new biometric login tests (6-9)