### PR TITLE
fix: rename LocalAuthentication.authenticate → authenticateAsync

### DIFF
--- a/mobile/app/(auth)/__tests__/login.test.tsx
+++ b/mobile/app/(auth)/__tests__/login.test.tsx
@@ -40,7 +40,7 @@ jest.mock('react-native-reanimated', () => {
 jest.mock('expo-local-authentication', () => ({
   hasHardwareAsync: jest.fn().mockResolvedValue(false),
   isEnrolledAsync: jest.fn().mockResolvedValue(false),
-  authenticate: jest.fn(),
+  authenticateAsync: jest.fn(),
 }))
 
 // Mock AsyncStorage — pref off by default → showForm=true
@@ -64,7 +64,7 @@ import { supabase } from '../../../src/lib/supabase'
 
 const mockHasHardware = LocalAuthentication.hasHardwareAsync as jest.Mock
 const mockIsEnrolled = LocalAuthentication.isEnrolledAsync as jest.Mock
-const mockAuthenticate = LocalAuthentication.authenticate as jest.Mock
+const mockAuthenticate = LocalAuthentication.authenticateAsync as jest.Mock
 const mockGetItem = AsyncStorage.getItem as jest.Mock
 const mockGetSession = supabase.auth.getSession as jest.Mock
 

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -38,7 +38,7 @@ export default function LoginScreen() {
   }))
 
   const triggerBiometric = async () => {
-    const result = await LocalAuthentication.authenticate({
+    const result = await LocalAuthentication.authenticateAsync({
       promptMessage: 'Sign in to VistaFi',
     })
     if (result.success) {


### PR DESCRIPTION
The correct expo-local-authentication API is authenticateAsync. The typo caused the type-check gate to fail in mobile-release.yml.